### PR TITLE
feat(executor): add functions to stream logs

### DIFF
--- a/cmd/server/operate.go
+++ b/cmd/server/operate.go
@@ -91,6 +91,14 @@ func operate(q queue.Service, e map[int]executor.Engine, t time.Duration) (err e
 					return err
 				}
 
+				// plan the build on the executor
+				logger.Info("creating build")
+				err = executor.PlanBuild(ctx)
+				if err != nil {
+					logger.Errorf("unable to plan build: %v", err)
+					return err
+				}
+
 				// execute the build on the executor
 				logger.Info("executing build")
 				err = executor.ExecBuild(ctx)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -30,13 +30,13 @@ type Engine interface {
 	// that kills the current build in execution.
 	KillBuild() (*library.Build, error)
 
-	// Secrets Engine interface functions
+	// Secrets Engine Interface Functions
 
 	// PullSecret defines a function that pulls
 	// the secrets for a given pipeline.
 	PullSecret(context.Context) error
 
-	// Service Engine interface functions
+	// Service Engine Interface Functions
 
 	// CreateService defines a function that
 	// configures the service for execution.
@@ -47,11 +47,14 @@ type Engine interface {
 	// ExecService defines a function that
 	// runs a service.
 	ExecService(context.Context, *pipeline.Container) error
+	// StreamService defines a function that
+	// tails the output for a service.
+	StreamService(context.Context, *pipeline.Container) error
 	// DestroyService defines a function that
 	// cleans up the service after execution.
 	DestroyService(context.Context, *pipeline.Container) error
 
-	// Step Engine interface functions
+	// Step Engine Interface Functions
 
 	// CreateStep defines a function that
 	// configures the step for execution.
@@ -62,18 +65,21 @@ type Engine interface {
 	// ExecStep defines a function that
 	// runs a step.
 	ExecStep(context.Context, *pipeline.Container) error
+	// StreamStep defines a function that
+	// tails the output for a step.
+	StreamStep(context.Context, *pipeline.Container) error
 	// DestroyStep defines a function that
 	// cleans up the step after execution.
 	DestroyStep(context.Context, *pipeline.Container) error
 
-	// Stage Engine interface functions
+	// Stage Engine Interface Functions
 
 	// CreateStage defines a function that
 	// configures the stage for execution.
 	CreateStage(context.Context, *pipeline.Stage) error
 	// PlanStage defines a function that
 	// prepares the stage for execution.
-	PlanStage(context.Context, *pipeline.Stage) error
+	PlanStage(context.Context, *pipeline.Stage, map[string]chan error) error
 	// ExecStage defines a function that
 	// runs a stage.
 	ExecStage(context.Context, *pipeline.Stage, map[string]chan error) error
@@ -86,6 +92,9 @@ type Engine interface {
 	// CreateBuild defines a function that
 	// configures the build for execution.
 	CreateBuild(context.Context) error
+	// PlanBuild defines a function that
+	// prepares the build for execution.
+	PlanBuild(context.Context) error
 	// ExecBuild defines a function that
 	// runs a pipeline for a build.
 	ExecBuild(context.Context) error

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -158,6 +158,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	if !ok {
 		err := fmt.Errorf("unable to get %s step from client", init.Name)
 		e = err
+
 		return err
 	}
 
@@ -167,6 +168,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	if !ok {
 		err := fmt.Errorf("unable to get %s step from client", init.Name)
 		e = err
+
 		return err
 	}
 

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -20,10 +20,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// CreateBuild prepares the build for execution.
+// CreateBuild configures the build for execution.
 func (c *client) CreateBuild(ctx context.Context) error {
 	b := c.build
-	p := c.pipeline
 	r := c.repo
 	e := c.err
 
@@ -77,6 +76,40 @@ func (c *client) CreateBuild(ctx context.Context) error {
 		return fmt.Errorf("unable to pull secrets: %v", err)
 	}
 
+	return nil
+}
+
+// PlanBuild defines a function that
+// prepares the build for execution.
+func (c *client) PlanBuild(ctx context.Context) error {
+	b := c.build
+	p := c.pipeline
+	r := c.repo
+	e := c.err
+
+	// update engine logger with extra metadata
+	c.logger = c.logger.WithFields(logrus.Fields{
+		"build": b.GetNumber(),
+		"repo":  r.GetFullName(),
+	})
+
+	defer func() {
+		// NOTE: When an error occurs during a build that does not have to do
+		// with a pipeline we should set build status to "error" not "failed"
+		// because it is worker related and not build.
+		if e != nil {
+			b.SetError(e.Error())
+			b.SetStatus(constants.StatusError)
+		}
+
+		c.logger.Info("uploading build state")
+		// send API call to update the build
+		_, _, err := c.Vela.Build.Update(r.GetOrg(), r.GetName(), b)
+		if err != nil {
+			c.logger.Errorf("unable to upload errorred state: %v", err)
+		}
+	}()
+
 	// TODO: make this better
 	init := new(pipeline.Container)
 	if len(p.Steps) > 0 {
@@ -84,7 +117,7 @@ func (c *client) CreateBuild(ctx context.Context) error {
 
 		c.logger.Infof("creating %s step", init.Name)
 		// create the step
-		err = c.CreateStep(ctx, init)
+		err := c.CreateStep(ctx, init)
 		if err != nil {
 			e = err
 			return fmt.Errorf("unable to create %s step: %w", init.Name, err)
@@ -105,7 +138,7 @@ func (c *client) CreateBuild(ctx context.Context) error {
 
 		c.logger.Infof("creating %s step", init.Name)
 		// create the step
-		err = c.CreateStep(ctx, init)
+		err := c.CreateStep(ctx, init)
 		if err != nil {
 			e = err
 			return fmt.Errorf("unable to create %s step: %w", init.Name, err)
@@ -123,16 +156,18 @@ func (c *client) CreateBuild(ctx context.Context) error {
 	// TODO: make this cleaner
 	result, ok := c.steps.Load(init.ID)
 	if !ok {
+		err := fmt.Errorf("unable to get %s step from client", init.Name)
 		e = err
-		return fmt.Errorf("unable to get %s step from client", init.Name)
+		return err
 	}
 
 	s := result.(*library.Step)
 
 	result, ok = c.stepLogs.Load(init.ID)
 	if !ok {
+		err := fmt.Errorf("unable to get %s step from client", init.Name)
 		e = err
-		return fmt.Errorf("unable to get %s step log from client", init.Name)
+		return err
 	}
 
 	l := result.(*library.Log)
@@ -141,7 +176,7 @@ func (c *client) CreateBuild(ctx context.Context) error {
 		s.SetFinished(time.Now().UTC().Unix())
 		c.logger.Infof("uploading %s step state", init.Name)
 		// send API call to update the step
-		s, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+		_, _, err := c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
 		if err != nil {
 			c.logger.Errorf("unable to upload %s state: %v", init.Name, err)
 		}
@@ -156,7 +191,7 @@ func (c *client) CreateBuild(ctx context.Context) error {
 
 	c.logger.Info("creating network")
 	// create the runtime network for the pipeline
-	err = c.Runtime.CreateNetwork(ctx, p)
+	err := c.Runtime.CreateNetwork(ctx, p)
 	if err != nil {
 		e = err
 		return fmt.Errorf("unable to create network: %w", err)
@@ -380,7 +415,7 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		result, ok := c.steps.Load(s.ID)
 		if !ok {
 			e = err
-			return fmt.Errorf("unable to get step from client")
+			return fmt.Errorf("unable to get step %s from client", s.Name)
 		}
 
 		cStep := result.(*library.Step)
@@ -426,9 +461,17 @@ func (c *client) ExecBuild(ctx context.Context) error {
 		stageMap[stage.Name] = make(chan error)
 
 		stages.Go(func() error {
+			c.logger.Infof("planning %s stage", stage.Name)
+			// plan the stage
+			err := c.PlanStage(stageCtx, stage, stageMap)
+			if err != nil {
+				e = err
+				return fmt.Errorf("unable to plan stage: %w", err)
+			}
+
 			c.logger.Infof("executing %s stage", stage.Name)
 			// execute the stage
-			err := c.ExecStage(stageCtx, stage, stageMap)
+			err = c.ExecStage(stageCtx, stage, stageMap)
 			if err != nil {
 				e = err
 				return fmt.Errorf("unable to execute stage: %w", err)

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -423,10 +423,14 @@ func TestExecutor_ExecBuild_Success(t *testing.T) {
 		e.WithPipeline(test.pipeline)
 		e.WithRepo(test.repo)
 
-		got := e.ExecBuild(context.Background())
+		err := e.PlanBuild(context.Background())
+		if err != nil {
+			t.Errorf("PlanBuild returned err: %v", err)
+		}
 
-		if got != nil {
-			t.Errorf("ExecBuild is %v, want nil", got)
+		err = e.ExecBuild(context.Background())
+		if err != nil {
+			t.Errorf("ExecBuild returned err: %v", err)
 		}
 	}
 }

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -105,7 +105,8 @@ func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error
 
 	go func() {
 		logger.Debug("stream logs for container")
-		err := c.StreamStep(ctx, ctn)
+		// stream logs from container
+		err := c.StreamService(ctx, ctn)
 		if err != nil {
 			logrus.Error(err)
 		}
@@ -182,6 +183,7 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 			l.SetData(append(l.GetData(), logs.Bytes()...))
 
 			logger.Debug("appending logs")
+			// send API call to append the logs for the service
 			l, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
 			if err != nil {
 				return err
@@ -198,7 +200,7 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 
 	logger.Debug("uploading logs")
 	// send API call to update the logs for the service
-	l, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+	_, _, err = c.Vela.Log.UpdateService(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
 	if err != nil {
 		return err
 	}

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -71,16 +71,8 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 	return nil
 }
 
-// TODO: Make this do stuff
-func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage) error {
-	return fmt.Errorf("this function is currently not supported")
-}
-
-// ExecStage runs a stage.
-func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
-	b := c.build
-	r := c.repo
-
+// PlanStage prepares the stage for execution.
+func (c *client) PlanStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
 	// update engine logger with extra metadata
 	logger := c.logger.WithFields(logrus.Fields{
 		"stage": s.Name,
@@ -111,6 +103,19 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 		}
 	}
 
+	return nil
+}
+
+// ExecStage runs a stage.
+func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]chan error) error {
+	b := c.build
+	r := c.repo
+
+	// update engine logger with extra metadata
+	logger := c.logger.WithFields(logrus.Fields{
+		"stage": s.Name,
+	})
+
 	// close the stage channel at the end
 	defer close(m[s.Name])
 
@@ -133,7 +138,7 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m map[string]
 
 		result, ok := c.steps.Load(step.ID)
 		if !ok {
-			return fmt.Errorf("unable to get step from client")
+			return fmt.Errorf("unable to get step %s from client", step.Name)
 		}
 
 		cStep := result.(*library.Step)

--- a/executor/linux/stage_test.go
+++ b/executor/linux/stage_test.go
@@ -49,11 +49,12 @@ func TestExecutor_CreateStage_Success(t *testing.T) {
 				Name: "init",
 				Steps: pipeline.ContainerSlice{
 					&pipeline.Container{
-						ID:     "__0_init_init",
-						Image:  "#init",
-						Name:   "init",
-						Number: 1,
-						Pull:   true,
+						ID:          "__0_init_init",
+						Environment: map[string]string{},
+						Image:       "#init",
+						Name:        "init",
+						Number:      1,
+						Pull:        true,
 					},
 				},
 			},
@@ -112,9 +113,9 @@ func TestExecutor_CreateStage_Success(t *testing.T) {
 	})
 
 	// run test
-	err := e.PlanStep(context.Background(), &pipeline.Container{ID: "__0_init_init"})
+	err := e.CreateStep(context.Background(), e.pipeline.Stages[0].Steps[0])
 	if err != nil {
-		t.Errorf("Unable to plan init step: %v", err)
+		t.Errorf("Unable to create init step: %v", err)
 	}
 
 	got := e.CreateStage(context.Background(), e.pipeline.Stages[1])
@@ -249,10 +250,19 @@ func TestExecutor_ExecStage_Success(t *testing.T) {
 	})
 
 	// run test
-	got := e.ExecStage(context.Background(), e.pipeline.Stages[0], stageMap)
+	err := e.CreateStep(context.Background(), e.pipeline.Stages[0].Steps[0])
+	if err != nil {
+		t.Errorf("Unable to create init step: %v", err)
+	}
 
-	if got != nil {
-		t.Errorf("ExecStage is %v, want nil", got)
+	err = e.CreateStage(context.Background(), e.pipeline.Stages[0])
+	if err != nil {
+		t.Errorf("CreateStage returned err: %v", err)
+	}
+
+	err = e.ExecStage(context.Background(), e.pipeline.Stages[0], stageMap)
+	if err != nil {
+		t.Errorf("ExecStage returned err: %v", err)
 	}
 }
 

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -23,8 +23,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// CreateStep prepares the step for execution.
+// CreateStep configures the step for execution.
 func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error {
+	var err error
+
+	b := c.build
+	r := c.repo
+
 	// update engine logger with extra metadata
 	logger := c.logger.WithFields(logrus.Fields{
 		"step": ctn.Name,
@@ -37,10 +42,53 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 	ctn.Environment["VELA_RUNTIME"] = "docker"
 	ctn.Environment["VELA_DISTRIBUTION"] = "linux"
 
+	// update the engine step object
+	s := new(library.Step)
+	s.SetName(ctn.Name)
+	s.SetNumber(ctn.Number)
+	s.SetStatus(constants.StatusRunning)
+	s.SetStarted(time.Now().UTC().Unix())
+	s.SetHost(ctn.Environment["VELA_HOST"])
+	s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
+	s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
+
+	logger.Debug("uploading step state")
+	// send API call to update the step
+	s, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+	if err != nil {
+		return err
+	}
+
+	s.SetStatus(constants.StatusSuccess)
+
+	// add a step to a map
+	c.steps.Store(ctn.ID, s)
+
+	// get the step log here
+	logger.Debug("retrieve step log")
+	// send API call to capture the step log
+	l, _, err := c.Vela.Log.GetStep(r.GetOrg(), r.GetName(), b.GetNumber(), s.GetNumber())
+	if err != nil {
+		return err
+	}
+
+	// add a step log to a map
+	c.stepLogs.Store(ctn.ID, l)
+
+	return nil
+}
+
+// PlanStep prepares the step for execution.
+func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	// TODO: remove hardcoded reference
 	if ctn.Name == "init" {
 		return nil
 	}
+
+	// update engine logger with extra metadata
+	logger := c.logger.WithFields(logrus.Fields{
+		"step": ctn.Name,
+	})
 
 	logger.Debug("setting up container")
 	// setup the runtime container
@@ -90,56 +138,57 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 	return nil
 }
 
-// PlanStep defines a function that prepares the step for execution.
-func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
-	var err error
-
-	b := c.build
-	r := c.repo
+// ExecStep runs a step.
+func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
+	// TODO: remove hardcoded reference
+	if ctn.Name == "init" {
+		return nil
+	}
 
 	// update engine logger with extra metadata
 	logger := c.logger.WithFields(logrus.Fields{
 		"step": ctn.Name,
 	})
 
-	// update the engine step object
-	s := new(library.Step)
-	s.SetName(ctn.Name)
-	s.SetNumber(ctn.Number)
-	s.SetStatus(constants.StatusRunning)
-	s.SetStarted(time.Now().UTC().Unix())
-	s.SetHost(ctn.Environment["VELA_HOST"])
-	s.SetRuntime(ctn.Environment["VELA_RUNTIME"])
-	s.SetDistribution(ctn.Environment["VELA_DISTRIBUTION"])
-
-	logger.Debug("uploading step state")
-	// send API call to update the step
-	s, _, err = c.Vela.Step.Update(r.GetOrg(), r.GetName(), b.GetNumber(), s)
+	logger.Debug("running container")
+	// run the runtime container
+	err := c.Runtime.RunContainer(ctx, c.pipeline, ctn)
 	if err != nil {
 		return err
 	}
 
-	s.SetStatus(constants.StatusSuccess)
+	go func() {
+		logger.Debug("stream logs for container")
+		err := c.StreamStep(ctx, ctn)
+		if err != nil {
+			logrus.Error(err)
+		}
+	}()
 
-	// add a step to a map
-	c.steps.Store(ctn.ID, s)
+	// do not wait for detached containers
+	if ctn.Detach {
+		return nil
+	}
 
-	// get the step log here
-	logger.Debug("retrieve step log")
-	// send API call to capture the step log
-	l, _, err := c.Vela.Log.GetStep(r.GetOrg(), r.GetName(), b.GetNumber(), s.GetNumber())
+	logger.Debug("waiting for container")
+	// wait for the runtime container
+	err = c.Runtime.WaitContainer(ctx, ctn)
 	if err != nil {
 		return err
 	}
 
-	// add a step log to a map
-	c.stepLogs.Store(ctn.ID, l)
+	logger.Debug("inspecting container")
+	// inspect the runtime container
+	err = c.Runtime.InspectContainer(ctx, ctn)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
-// ExecStep runs a step.
-func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
+// StreamStep tails the output for a step.
+func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error {
 	// TODO: remove hardcoded reference
 	if ctn.Name == "init" {
 		return nil
@@ -160,80 +209,51 @@ func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
 		"step": ctn.Name,
 	})
 
-	logger.Debug("running container")
-	// run the runtime container
-	err := c.Runtime.RunContainer(ctx, c.pipeline, ctn)
-	if err != nil {
-		return err
-	}
-
 	// create new buffer for uploading logs
 	logs := new(bytes.Buffer)
-	go func() error {
-		logger.Debug("tailing container")
-		// tail the runtime container
-		rc, err := c.Runtime.TailContainer(ctx, ctn)
-		if err != nil {
-			return err
-		}
-		defer rc.Close()
 
-		// create new scanner from the container output
-		scanner := bufio.NewScanner(rc)
-
-		// scan entire container output
-		for scanner.Scan() {
-			// write all the logs from the scanner
-			logs.Write(append(scanner.Bytes(), []byte("\n")...))
-
-			// if we have at least 1000 bytes in our buffer
-			if logs.Len() > 1000 {
-				logger.Trace(logs.String())
-
-				// update the existing log with the new bytes
-				l.SetData(append(l.GetData(), logs.Bytes()...))
-
-				logger.Debug("appending logs")
-				// send API call to update the logs for the step
-				l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
-				if err != nil {
-					return err
-				}
-
-				// flush the buffer of logs
-				logs.Reset()
-			}
-		}
-		logger.Trace(logs.String())
-
-		// update the existing log with the last bytes
-		l.SetData(append(l.GetData(), logs.Bytes()...))
-
-		logger.Debug("uploading logs")
-		// send API call to update the logs for the step
-		l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}()
-
-	// do not wait for detached containers
-	if ctn.Detach {
-		return nil
-	}
-
-	logger.Debug("waiting for container")
-	// wait for the runtime container
-	err = c.Runtime.WaitContainer(ctx, ctn)
+	logger.Debug("tailing container")
+	// tail the runtime container
+	rc, err := c.Runtime.TailContainer(ctx, ctn)
 	if err != nil {
 		return err
 	}
+	defer rc.Close()
 
-	logger.Debug("inspecting container")
-	// inspect the runtime container
-	err = c.Runtime.InspectContainer(ctx, ctn)
+	// create new scanner from the container output
+	scanner := bufio.NewScanner(rc)
+
+	// scan entire container output
+	for scanner.Scan() {
+		// write all the logs from the scanner
+		logs.Write(append(scanner.Bytes(), []byte("\n")...))
+
+		// if we have at least 1000 bytes in our buffer
+		if logs.Len() > 1000 {
+			logger.Trace(logs.String())
+
+			// update the existing log with the new bytes
+			l.SetData(append(l.GetData(), logs.Bytes()...))
+
+			logger.Debug("appending logs")
+			// send API call to update the logs for the step
+			l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+			if err != nil {
+				return err
+			}
+
+			// flush the buffer of logs
+			logs.Reset()
+		}
+	}
+	logger.Trace(logs.String())
+
+	// update the existing log with the last bytes
+	l.SetData(append(l.GetData(), logs.Bytes()...))
+
+	logger.Debug("uploading logs")
+	// send API call to update the logs for the step
+	l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
 	if err != nil {
 		return err
 	}

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -159,6 +159,7 @@ func (c *client) ExecStep(ctx context.Context, ctn *pipeline.Container) error {
 
 	go func() {
 		logger.Debug("stream logs for container")
+		// stream logs from container
 		err := c.StreamStep(ctx, ctn)
 		if err != nil {
 			logrus.Error(err)
@@ -236,7 +237,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 			l.SetData(append(l.GetData(), logs.Bytes()...))
 
 			logger.Debug("appending logs")
-			// send API call to update the logs for the step
+			// send API call to append the logs for the step
 			l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
 			if err != nil {
 				return err
@@ -253,7 +254,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 
 	logger.Debug("uploading logs")
 	// send API call to update the logs for the step
-	l, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
+	_, _, err = c.Vela.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), ctn.Number, l)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The GolangCI check is failing because of the linter checks.

[I went through and fixed](https://github.com/go-vela/worker/pull/66/commits/ce597fe814bc1a05acb7a5ad1d3bc32d22d20f8c) **most of the issues**, but it's still complaining about the length of our function for only one (`PlanBuild`).

https://golangci.com/r/github.com/go-vela/worker/pulls/66

I'd vote we skip the linter failure and not worry about it 👍 