### PR TITLE
fix: explictly make executor map

### DIFF
--- a/cmd/vela-worker/run.go
+++ b/cmd/vela-worker/run.go
@@ -87,6 +87,7 @@ func run(c *cli.Context) error {
 				Secret:  c.String("server.secret"),
 			},
 		},
+		Executors: make(map[int]executor.Engine),
 	}
 
 	// validate the worker


### PR DESCRIPTION
This prevents a `panic` when we attempt to create a new `executor` and add it to our collection of executors.

The code that does this can be found here:

https://github.com/go-vela/worker/blob/6bf556146feec9c8869a17faef914ae4888ef99b/cmd/vela-worker/operate.go#L55-L65

We store a collection of executors so we can query the builds being ran and kill them if need be 👍 