### PR TITLE
chore: set hostname in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       context: .
     container_name: worker_1
     image: worker:local
+    hostname: http://worker_1
     networks:
       - vela
     environment:
@@ -33,6 +34,7 @@ services:
       context: .    
     container_name: worker_2
     image: worker:local
+    hostname: http://worker_2
     networks:
       - vela
     environment:


### PR DESCRIPTION
Adding hostnames to worker containers in docker-compose to allow the server to address the worker api locally.