### PR TITLE
feat: allow server to run with TLS

### DIFF
--- a/cmd/vela-worker/flags.go
+++ b/cmd/vela-worker/flags.go
@@ -77,6 +77,16 @@ func flags() []cli.Flag {
 			Name:    "server.secret",
 			Usage:   "secret used for server <-> worker communication",
 		},
+		&cli.StringFlag{
+			EnvVars: []string{"WORKER_SERVER_CERT", "VELA_SERVER_CERT", "SERVER_CERT"},
+			Name:    "server.cert",
+			Usage:   "optional TLS certificate for https",
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"WORKER_SERVER_CERT_KEY", "VELA_SERVER_CERT_KEY", "SERVER_CERT_KEY"},
+			Name:    "server.cert-key",
+			Usage:   "optional TLS certificate key",
+		},
 	}
 
 	// Executor Flags

--- a/cmd/vela-worker/run.go
+++ b/cmd/vela-worker/run.go
@@ -110,6 +110,11 @@ func run(c *cli.Context) error {
 				Address: c.String("server.addr"),
 				Secret:  c.String("server.secret"),
 			},
+			// Certificate configuration
+			Certificate: &Certificate{
+				Cert: c.String("server.cert"),
+				Key:  c.String("server.cert-key"),
+			},
 		},
 		Executors: make(map[int]executor.Engine),
 	}

--- a/cmd/vela-worker/server.go
+++ b/cmd/vela-worker/server.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"os"
 	"time"
 
 	"github.com/go-vela/worker/router"
@@ -36,7 +37,14 @@ func (w *Worker) server() error {
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Tracef
 	logrus.Tracef("serving traffic on %s", w.Config.API.Port)
 
-	// start serving traffic on the provided worker port
+	// start serving traffic with TLS on the provided worker port
+	//
+	// https://pkg.go.dev/github.com/gin-gonic/gin?tab=doc#Engine.RunTLS
+	if os.Getenv("server-cert") != "" {
+		return _server.RunTLS(w.Config.API.Port, os.Getenv("server-cert"), os.Getenv("server-key"))
+	}
+
+	// if no certs are provided, run without TLS
 	//
 	// https://pkg.go.dev/github.com/gin-gonic/gin?tab=doc#Engine.Run
 	return _server.Run(w.Config.API.Port)

--- a/cmd/vela-worker/server.go
+++ b/cmd/vela-worker/server.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"os"
 	"time"
 
 	"github.com/go-vela/worker/router"
@@ -40,8 +39,8 @@ func (w *Worker) server() error {
 	// start serving traffic with TLS on the provided worker port
 	//
 	// https://pkg.go.dev/github.com/gin-gonic/gin?tab=doc#Engine.RunTLS
-	if os.Getenv("server-cert") != "" {
-		return _server.RunTLS(w.Config.API.Port, os.Getenv("server-cert"), os.Getenv("server-key"))
+	if len(w.Config.Certificate.Cert) > 0 {
+		return _server.RunTLS(w.Config.API.Port, w.Config.Certificate.Cert, w.Config.Certificate.Key)
 	}
 
 	// if no certs are provided, run without TLS

--- a/cmd/vela-worker/worker.go
+++ b/cmd/vela-worker/worker.go
@@ -37,16 +37,23 @@ type (
 		Secret  string
 	}
 
+	// Certificate represents the optional cert and key to enable TLS
+	Certificate struct {
+		Cert string
+		Key  string
+	}
+
 	// Config represents the worker configuration.
 	Config struct {
-		API      *API
-		Build    *Build
-		Executor *executor.Setup
-		Hostname string
-		Logger   *Logger
-		Queue    *queue.Setup
-		Runtime  *runtime.Setup
-		Server   *Server
+		API         *API
+		Build       *Build
+		Executor    *executor.Setup
+		Hostname    string
+		Logger      *Logger
+		Queue       *queue.Setup
+		Runtime     *runtime.Setup
+		Server      *Server
+		Certificate *Certificate
 	}
 
 	// Worker represents all configuration and


### PR DESCRIPTION
Allows (optionally) setting a certificate which is then used in [RunTLS](https://pkg.go.dev/github.com/gin-gonic/gin?tab=doc#Engine.RunTLS)

If certs are not provided, the functionality stays the same as the current state.