### PR TITLE
refactor: secrets.env -> .env for consistency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@
 # default: https://go-vela.github.io/docs
 # VELA_DOCS_URL=
 
+# customize the location for the Vela server address
+#
+# Should match the "VELA_ADDR" value in docker-compose.yml when running locally.
+VELA_API=http://localhost:8080
+
 ############################################################
 #  _______  _______  ______    __   __  _______  ______    #
 # |       ||       ||    _ |  |  | |  ||       ||    _ |   #

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,9 @@ release/
 # Secrets environment file
 secrets.env
 
+# Dotenv environment file
+.env
+.env.test
+
 # Files to be excluded.
 .DS_Store

--- a/DOCS.md
+++ b/DOCS.md
@@ -34,11 +34,11 @@ git clone git@github.com:go-vela/worker.git $HOME/go-vela/worker
 cd $HOME/go-vela/worker
 ```
 
-* If using GitHub Enterprise (default: `https://github.com/`), add the Web URL to a local `secrets.env` file:
+* If using GitHub Enterprise (default: `https://github.com/`), add the Web URL to a local `.env` file:
 
 ```bash
-# add Github Enterprise Web URL to local secrets file for `docker-compose`
-echo "VELA_SOURCE_URL=<GitHub Enterprise Web URL>" >> secrets.env
+# add Github Enterprise Web URL to local `.env` file for `docker-compose`
+echo "VELA_SOURCE_URL=<GitHub Enterprise Web URL>" >> .env
 ```
 
 * Create an [OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) and obtain secrets for local development:
@@ -46,14 +46,14 @@ echo "VELA_SOURCE_URL=<GitHub Enterprise Web URL>" >> secrets.env
   * `Homepage URL` = `http://localhost:8080` (base URL of the server)
   * `Authorization callback URL` = `http://localhost:8888/account/authenticate` (authenticate endpoint of the base URL of the UI)
 
-* Add OAuth client secrets to a local `secrets.env` file:
+* Add OAuth client secrets to a local `.env` file:
 
 ```bash
-# add Github Client ID to local secrets file for `docker-compose`
-echo "VELA_SOURCE_CLIENT=<Github OAuth Client ID>" >> secrets.env
+# add Github Client ID to local `.env` file for `docker-compose`
+echo "VELA_SOURCE_CLIENT=<Github OAuth Client ID>" >> .env
 
-# add Github Client Secret to local secrets file for `docker-compose`
-echo "VELA_SOURCE_SECRET=<Github OAuth Client Secret>" >> secrets.env
+# add Github Client Secret to local `.env` file for `docker-compose`
+echo "VELA_SOURCE_SECRET=<Github OAuth Client Secret>" >> .env
 ```
 
 ## Start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       VELA_SECRET_VAULT_TOKEN: vela
       VELA_DISABLE_WEBHOOK_VALIDATION: 'true'
     env_file:
-      - secrets.env
+      - .env
     restart: always
     ports:
       - '8080:8080'
@@ -88,10 +88,8 @@ services:
     image: target/vela-ui:latest
     networks:
       - vela
-    environment:
-      VELA_API: 'http://localhost:8080'
     env_file:
-      - secrets.env
+      - .env
     restart: always
     ports:
       - '8888:80'


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/150

Related to https://github.com/go-vela/ui/pull/232

Updates all references to `secrets.env` to now be `.env` to remain consistent with [go-vela/ui](https://github.com/go-vela/ui)