### PR TITLE
feat: add allow list for privileged containers

### DIFF
--- a/cmd/vela-worker/run.go
+++ b/cmd/vela-worker/run.go
@@ -95,10 +95,11 @@ func run(c *cli.Context) error {
 			},
 			// runtime configuration
 			Runtime: &runtime.Setup{
-				Driver:    c.String("runtime.driver"),
-				Config:    c.String("runtime.config"),
-				Namespace: c.String("runtime.namespace"),
-				Volumes:   c.StringSlice("runtime.volumes"),
+				Driver:           c.String("runtime.driver"),
+				Config:           c.String("runtime.config"),
+				Namespace:        c.String("runtime.namespace"),
+				Volumes:          c.StringSlice("runtime.volumes"),
+				PrivilegedImages: c.StringSlice("runtime.allowed-privileged-images"),
 			},
 			// queue configuration
 			Queue: &queue.Setup{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-vela/pkg-executor v0.6.1-0.20201113131900-4f44bbe0ef33
 	github.com/go-vela/pkg-queue v0.6.0
-	github.com/go-vela/pkg-runtime v0.6.1-0.20201111181755-32e183648cb0
+	github.com/go-vela/pkg-runtime v0.6.1-0.20201117152311-83cd0f9fc2b1
 	github.com/go-vela/sdk-go v0.6.1-0.20201023131354-0be3cce3f55d
 	github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538
 	github.com/joho/godotenv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/go-vela/pkg-queue v0.6.0 h1:8lOntes/6iSzKnXvO2zyvZI2iPwEnA4/7YD0UIIOJ
 github.com/go-vela/pkg-queue v0.6.0/go.mod h1:hhTidV8kpbL88TDE7UTv1j2ZqnUYD2Q8jhrGE/RFNfg=
 github.com/go-vela/pkg-runtime v0.6.1-0.20201111181755-32e183648cb0 h1:2/+ArGyca6INrEMQuKQZMe3KxvNNjzyF/fMxrSvAIrM=
 github.com/go-vela/pkg-runtime v0.6.1-0.20201111181755-32e183648cb0/go.mod h1:fk1yFX7YTyO/8nhZ9jGG2t9d8R9GbTuz1C8OAUlzBqg=
+github.com/go-vela/pkg-runtime v0.6.1-0.20201117152311-83cd0f9fc2b1 h1:RgYGFtBaUKV8bRXEll2ORQjhMTqEQMxsmXm0i9R2V1E=
+github.com/go-vela/pkg-runtime v0.6.1-0.20201117152311-83cd0f9fc2b1/go.mod h1:fk1yFX7YTyO/8nhZ9jGG2t9d8R9GbTuz1C8OAUlzBqg=
 github.com/go-vela/sdk-go v0.6.0 h1:UMO/wvW2nkh+yqFcE4q2T1db7wPY1uN7+WaAV2DJyMY=
 github.com/go-vela/sdk-go v0.6.0/go.mod h1:USILVcPdhS2hWbLNjnEXfb+gzQUkrAp51GUbEtIsdTE=
 github.com/go-vela/sdk-go v0.6.1-0.20201023131354-0be3cce3f55d h1:TcI7AMKRCRe/jeKS9gtMkQDtLztBeR3ix/9+VR3Kvuo=


### PR DESCRIPTION
Adding the `runtime.allowed-privileged-images` flag from https://github.com/go-vela/pkg-runtime/pull/62.