### PR TITLE
fix: remove nil check from worker registration

### DIFF
--- a/cmd/vela-worker/register.go
+++ b/cmd/vela-worker/register.go
@@ -19,10 +19,6 @@ func (w *Worker) register(config *library.Worker) error {
 	// check to see if the worker already exists in the database
 	_, resp, err := w.VelaClient.Worker.Get(config.GetHostname())
 	if err != nil {
-		// check to see if the response was nil
-		if resp == nil {
-			return fmt.Errorf("unable to retrieve worker %s from the server: %v", config.GetHostname(), err)
-		}
 		// check to see if the worker was not found and if we need to add it
 		if resp.StatusCode == http.StatusNotFound {
 			logrus.Infof("registering worker %s with the server", config.GetHostname())


### PR DESCRIPTION
Removing a check that isn't currently checking anything. If we remove this check the error is still caught below. Currently this is causing an issue when attempting to add a worker that doesn't yet exist in the db.