### PR TITLE
fix: allow workers to retry registering with the server

### DIFF
--- a/cmd/vela-worker/register.go
+++ b/cmd/vela-worker/register.go
@@ -20,8 +20,7 @@ func (w *Worker) checkIn(config *library.Worker) error {
 	if err != nil {
 		// if we receive a 404 the worker needs to be registered
 		if resp.StatusCode == http.StatusNotFound {
-			w.register(config)
-			return nil
+			return w.register(config)
 		}
 
 		return fmt.Errorf("unable to retrieve worker %s from the server: %v", config.GetHostname(), err)
@@ -48,5 +47,4 @@ func (w *Worker) register(config *library.Worker) error {
 
 	// successfully added the worker so return nil
 	return nil
-
 }

--- a/cmd/vela-worker/register.go
+++ b/cmd/vela-worker/register.go
@@ -12,36 +12,41 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// register is a helper function to register
-// the worker in the database, updating the item
-// if the worker already exists
-func (w *Worker) register(config *library.Worker) error {
+// checkIn is a helper function to to phone home to the server
+func (w *Worker) checkIn(config *library.Worker) error {
 	// check to see if the worker already exists in the database
+	logrus.Infof("retrieving worker %s from the server", config.GetHostname())
 	_, resp, err := w.VelaClient.Worker.Get(config.GetHostname())
 	if err != nil {
-		// check to see if the worker was not found and if we need to add it
+		// if we receive a 404 the worker needs to be registered
 		if resp.StatusCode == http.StatusNotFound {
-			logrus.Infof("registering worker %s with the server", config.GetHostname())
-			_, _, err := w.VelaClient.Worker.Add(config)
-			if err != nil {
-				// log the error instead of returning so the operation doesn't block worker deployment
-				return fmt.Errorf("unable to register worker %s with the server: %v", config.GetHostname(), err)
-			}
-
-			// successfully added the worker so return nil
+			w.register(config)
 			return nil
 		}
 
 		return fmt.Errorf("unable to retrieve worker %s from the server: %v", config.GetHostname(), err)
 	}
 
-	// the worker exists in the db, update it with the new config
-	logrus.Infof("worker %s previously registered with server, updating information", config.GetHostname())
+	// if we were able to GET the worker, update it
+	logrus.Infof("checking worker %s into the server", config.GetHostname())
 	_, _, err = w.VelaClient.Worker.Update(config.GetHostname(), config)
 	if err != nil {
-		// log the error instead of returning so the operation doesn't block worker deployment
 		return fmt.Errorf("unable to update worker %s on the server: %v", config.GetHostname(), err)
 	}
 
 	return nil
+}
+
+// register is a helper function to register the worker with the server
+func (w *Worker) register(config *library.Worker) error {
+	logrus.Infof("worker %s not found, registering it with the server", config.GetHostname())
+	_, _, err := w.VelaClient.Worker.Add(config)
+	if err != nil {
+		// log the error instead of returning so the operation doesn't block worker deployment
+		return fmt.Errorf("unable to register worker %s with the server: %v", config.GetHostname(), err)
+	}
+
+	// successfully added the worker so return nil
+	return nil
+
 }


### PR DESCRIPTION
mades the registration process a little more readable and allows the worker to retry registering if the worker was not previously registered. This removes a race condition where the server must be available before the worker

fixes https://github.com/go-vela/community/issues/185