### PR TITLE
fix: web UI address for server in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - vela
     environment:
       VELA_ADDR: 'http://localhost:8080'
-      VELA_WEBUI_ADDR: 'http://ui:80'
+      VELA_WEBUI_ADDR: 'http://localhost:8888'
       VELA_DATABASE_DRIVER: postgres
       VELA_DATABASE_CONFIG: 'postgres://vela:zB7mrKDTZqNeNTD8z47yG4DHywspAh@postgres:5432/vela?sslmode=disable'
       VELA_LOG_LEVEL: trace


### PR DESCRIPTION
I was attempting to test some changes locally in the [go-vela/pkg-executor](https://github.com/go-vela/pkg-executor) codebase.

When I attempted to run a `make up` in this repo and login to the UI on http://localhost:8888 it wouldn't work.

After looking at the compose setup in [go-vela/server](https://github.com/go-vela/server) I realized that we changed the `VELA_WEBUI_ADDR` variable.

It appears we modified this variable in https://github.com/go-vela/server/pull/241 and never made the same change here.