### PR TITLE
feat: add version information to executor

### DIFF
--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-vela/pkg-executor/executor"
 	"github.com/go-vela/pkg-runtime/runtime"
+	"github.com/go-vela/worker/version"
 
 	"github.com/sirupsen/logrus"
 )
@@ -22,6 +23,9 @@ import (
 // nolint:funlen // ignore function length due to comments and log messages
 func (w *Worker) exec(index int) error {
 	var err error
+
+	// setup the version
+	v := version.New()
 
 	// setup the runtime
 	//
@@ -49,6 +53,7 @@ func (w *Worker) exec(index int) error {
 		Pipeline: item.Pipeline.Sanitize(w.Config.Runtime.Driver),
 		Repo:     item.Repo,
 		User:     item.User,
+		Version:  v.Semantic(),
 	})
 
 	// add the executor to the worker
@@ -58,9 +63,10 @@ func (w *Worker) exec(index int) error {
 	//
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#WithFields
 	logger := logrus.WithFields(logrus.Fields{
-		"build": item.Build.GetNumber(),
-		"host":  w.Config.API.Address.Hostname(),
-		"repo":  item.Repo.GetFullName(),
+		"build":   item.Build.GetNumber(),
+		"host":    w.Config.API.Address.Hostname(),
+		"repo":    item.Repo.GetFullName(),
+		"version": v.Semantic(),
 	})
 
 	// capture the configured build timeout

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/gin-gonic/gin v1.6.3
-	github.com/go-vela/pkg-executor v0.7.0-rc2
+	github.com/go-vela/pkg-executor v0.7.0-rc2.0.20210125155500-a6fec1db703f
 	github.com/go-vela/pkg-queue v0.7.0-rc2
 	github.com/go-vela/pkg-runtime v0.7.0-rc2
 	github.com/go-vela/sdk-go v0.7.0-rc2

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/go-vela/compiler v0.7.0-rc2 h1:oqEzF1rbQYTDepgWX5YWVmoPMHwYCPZFByb4WE
 github.com/go-vela/compiler v0.7.0-rc2/go.mod h1:yDLkztd1U/29EPleiBbkNzPWnxxUwvKNGYMTX3pYPQ8=
 github.com/go-vela/mock v0.7.0-rc2 h1:n+ugukio7vQrmOZ5D2td+BuGufqrT2HT3gZHO1UPeRc=
 github.com/go-vela/mock v0.7.0-rc2/go.mod h1:PzRHohJqr9xLxpe8482/kwL9bHy2YuKtOhzMohxYaYk=
-github.com/go-vela/pkg-executor v0.7.0-rc2 h1:Tlv6oMZDKU0CkT1GP3KsI6xmYEGvRGblD9Tz3Y/wdI4=
-github.com/go-vela/pkg-executor v0.7.0-rc2/go.mod h1:fZSgpMre5zppQayDBXvHk+OhTc69IVzxEl0PnniVxPk=
+github.com/go-vela/pkg-executor v0.7.0-rc2.0.20210125155500-a6fec1db703f h1:ONz4EBCrIXhQVsxnPL7g0xZEmdtIf82AhQUh5rpKslw=
+github.com/go-vela/pkg-executor v0.7.0-rc2.0.20210125155500-a6fec1db703f/go.mod h1:fZSgpMre5zppQayDBXvHk+OhTc69IVzxEl0PnniVxPk=
 github.com/go-vela/pkg-queue v0.7.0-rc2 h1:moOWGXmZXGgLnFEappElfkkrF1hj9yXA7D2B+47VDTA=
 github.com/go-vela/pkg-queue v0.7.0-rc2/go.mod h1:UCfvqjVN+88FDApBRPdIQ/lgvpuoBsn8jyvsjwq9CnM=
 github.com/go-vela/pkg-runtime v0.7.0-rc2 h1:/t1F4wXsGsk1vEdKH6asadD3IeK6ocjmaytlp1AwGXM=


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

Based off of https://github.com/go-vela/pkg-executor/pull/110

This will set the version information for the executor which is used in logs and environment variables.