### PR TITLE
chore: linter setup and fixes, doc changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,6 +63,22 @@ cd $HOME/go-vela/worker
 
 * Write your code and tests to implement the changes you desire.
   * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
+
+    ```go
+    // nolint:<linter(s)> // <short reason>
+    ```
+  
+    Example:
+
+    ```go
+    // nolint:gocyclo // legacy function is complex, needs simplification
+    func superComplexFunction() error {
+      // ..
+    }
+    ```
+
+    Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
 
 * Run the repository code (ensures your changes perform as you desire):
 
@@ -92,4 +108,25 @@ make clean
 git push fork master
 ```
 
-* Open a pull request. Thank you for your contribution!
+* Open a pull request!
+  * For the title of the pull request, please use the following format for the title:
+
+    ```text
+    feat(wobble): add hat wobble
+    ^--^^------^  ^------------^
+    |   |         |
+    |   |         +---> Summary in present tense.
+    |   +---> Scope: a noun describing a section of the codebase (optional)
+    +---> Type: chore, docs, feat, fix, refactor, or test.
+    ```
+
+    * feat: adds a new feature (equivalent to a MINOR in Semantic Versioning)
+    * fix: fixes a bug (equivalent to a PATCH in Semantic Versioning)
+    * docs: changes to the documentation
+    * refactor: refactors production code, eg. renaming a variable; doesn't change public API
+    * test: adds missing tests, refactors tests; no production code change
+    * chore: updates something without impacting the user (ex: bump a dependency in package.json or go.mod); no production code change
+
+    If a code change introduces a breaking change, place ! suffix after type, ie. feat(change)!: adds breaking change. correlates with MAJOR in semantic versioning.
+
+Thank you for your contribution!

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,10 +56,10 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space) 
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -131,7 +131,9 @@ issues:
     # prevent linters from running on *_test.go files
     - path: _test\.go
       linters:
+        - dupl
         - funlen
         - goconst
         - gocyclo
         - gomnd
+        - lll

--- a/api/executor.go
+++ b/api/executor.go
@@ -123,7 +123,7 @@ func GetExecutors(c *gin.Context) {
 	// capture executors value from context
 	value := c.Value("executors")
 	if value == nil {
-		msg := fmt.Sprintf("no running executors found")
+		msg := "no running executors found"
 
 		c.AbortWithStatusJSON(http.StatusInternalServerError, types.Error{Message: &msg})
 
@@ -133,7 +133,7 @@ func GetExecutors(c *gin.Context) {
 	// cast executors value to expected type
 	e, ok := value.(map[int]executor.Engine)
 	if !ok {
-		msg := fmt.Sprintf("unable to get executors")
+		msg := "unable to get executors"
 
 		c.AbortWithStatusJSON(http.StatusInternalServerError, types.Error{Message: &msg})
 

--- a/api/health.go
+++ b/api/health.go
@@ -25,7 +25,7 @@ import (
 //     schema:
 //       type: string
 
-// Health check the status of the application
+// Health check the status of the application.
 func Health(c *gin.Context) {
 	c.JSON(http.StatusOK, "ok")
 }

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -25,7 +25,7 @@ import (
 //     schema:
 //       type: string
 
-// Metrics returns a Prometheus handler for serving go metrics
+// Metrics returns a Prometheus handler for serving go metrics.
 func Metrics() http.Handler {
 	return promhttp.Handler()
 }

--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -20,6 +20,7 @@ import (
 
 // exec is a helper function to poll the queue
 // and execute Vela pipelines for the Worker.
+//
 // nolint:funlen // ignore function length due to comments and log messages
 func (w *Worker) exec(index int) error {
 	var err error

--- a/cmd/vela-worker/register.go
+++ b/cmd/vela-worker/register.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// checkIn is a helper function to to phone home to the server
+// checkIn is a helper function to to phone home to the server.
 func (w *Worker) checkIn(config *library.Worker) error {
 	// check to see if the worker already exists in the database
 	logrus.Infof("retrieving worker %s from the server", config.GetHostname())
@@ -36,7 +36,7 @@ func (w *Worker) checkIn(config *library.Worker) error {
 	return nil
 }
 
-// register is a helper function to register the worker with the server
+// register is a helper function to register the worker with the server.
 func (w *Worker) register(config *library.Worker) error {
 	logrus.Infof("worker %s not found, registering it with the server", config.GetHostname())
 	_, _, err := w.VelaClient.Worker.Add(config)

--- a/cmd/vela-worker/run.go
+++ b/cmd/vela-worker/run.go
@@ -23,6 +23,8 @@ import (
 
 // run executes the worker based
 // off the configuration provided.
+//
+// nolint: funlen // ignore function length due to comments
 func run(c *cli.Context) error {
 	// set log format for the worker
 	switch c.String("log.format") {

--- a/cmd/vela-worker/start.go
+++ b/cmd/vela-worker/start.go
@@ -71,6 +71,8 @@ func (w *Worker) Start() error {
 		}()
 
 		// create an infinite loop to poll for errors
+		//
+		// nolint: gosimple // ignore this for now
 		for {
 			// create a select statement to check for errors
 			select {

--- a/cmd/vela-worker/worker.go
+++ b/cmd/vela-worker/worker.go
@@ -38,7 +38,7 @@ type (
 		Secret  string
 	}
 
-	// Certificate represents the optional cert and key to enable TLS
+	// Certificate represents the optional cert and key to enable TLS.
 	Certificate struct {
 		Cert string
 		Key  string

--- a/router/build.go
+++ b/router/build.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-vela/worker/api"
 )
 
+// nolint: godot // ignore comment ending in period
+//
 // BuildHandlers extends the provided base router group
 // by adding a collection of endpoints for handling
 // build related requests.

--- a/router/executor.go
+++ b/router/executor.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-vela/worker/router/middleware/executor"
 )
 
+// nolint: godot // ignore comment ending in period
+//
 // ExecutorHandlers extends the provided base router group
 // by adding a collection of endpoints for handling
 // executor related requests.

--- a/router/middleware/executor/executor.go
+++ b/router/middleware/executor/executor.go
@@ -17,12 +17,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Retrieve gets the repo in the given context
+// Retrieve gets the repo in the given context.
 func Retrieve(c *gin.Context) executor.Engine {
 	return executor.FromGinContext(c)
 }
 
-// Establish sets the executor in the given context
+// Establish sets the executor in the given context.
 func Establish() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		param := c.Param("executor")
@@ -46,7 +46,7 @@ func Establish() gin.HandlerFunc {
 		// capture executors value from context
 		value := c.Value("executors")
 		if value == nil {
-			msg := fmt.Sprintf("no running executors found")
+			msg := "no running executors found"
 
 			c.AbortWithStatusJSON(http.StatusInternalServerError, types.Error{Message: &msg})
 
@@ -56,7 +56,7 @@ func Establish() gin.HandlerFunc {
 		// cast executors value to expected type
 		executors, ok := value.(map[int]executor.Engine)
 		if !ok {
-			msg := fmt.Sprintf("unable to get executors")
+			msg := "unable to get executors"
 
 			c.AbortWithStatusJSON(http.StatusInternalServerError, types.Error{Message: &msg})
 

--- a/router/middleware/header.go
+++ b/router/middleware/header.go
@@ -33,6 +33,7 @@ func Options(c *gin.Context) {
 		c.Header("Access-Control-Allow-Headers", "authorization, origin, content-type, accept")
 		c.Header("Allow", "HEAD,GET,POST,PUT,PATCH,DELETE,OPTIONS")
 		c.Header("Content-Type", "application/json")
+		// nolint: gomnd // ignore magic number
 		c.AbortWithStatus(200)
 	}
 }

--- a/router/middleware/logger_test.go
+++ b/router/middleware/logger_test.go
@@ -80,6 +80,7 @@ func TestMiddleware_Logger_Error(t *testing.T) {
 	// setup mock server
 	engine.Use(Logger(logger, time.RFC3339, true))
 	engine.GET("/foobar", func(c *gin.Context) {
+		// nolint: errcheck // ignore checking error
 		c.Error(fmt.Errorf("test error"))
 		c.Status(http.StatusOK)
 	})

--- a/router/middleware/payload.go
+++ b/router/middleware/payload.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Payload is a middleware function that captures the user provided json body
-// and attaches it to the context of every http.Request to be logged
+// and attaches it to the context of every http.Request to be logged.
 func Payload() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// bind JSON payload from request to be added to context

--- a/router/middleware/perm/doc.go
+++ b/router/middleware/perm/doc.go
@@ -9,5 +9,4 @@
 // Usage:
 //
 // 	import "github.com/go-vela/worker/router/middleware/perm"
-
 package perm

--- a/router/middleware/perm/perm.go
+++ b/router/middleware/perm/perm.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// MustServer ensures the user is the vela server
+// MustServer ensures the user is the vela server.
 func MustServer() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		u := user.Retrieve(c)

--- a/router/middleware/token/doc.go
+++ b/router/middleware/token/doc.go
@@ -9,5 +9,4 @@
 // Usage:
 //
 // 	import "github.com/go-vela/worker/router/middleware/token"
-
 package token

--- a/router/middleware/token/token.go
+++ b/router/middleware/token/token.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+// nolint: godot // ignore comment ending in period
+//
 // Retrieve gets the token from the provided request http.Request
 // to be parsed and validated. This is called on every request
 // to enable capturing the user making the request and validating

--- a/router/middleware/user/doc.go
+++ b/router/middleware/user/doc.go
@@ -9,5 +9,4 @@
 // Usage:
 //
 // 	import "github.com/go-vela/worker/router/middleware/user"
-
 package user

--- a/router/middleware/user/user.go
+++ b/router/middleware/user/user.go
@@ -15,12 +15,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// Retrieve gets the user in the given context
+// Retrieve gets the user in the given context.
 func Retrieve(c *gin.Context) *library.User {
 	return FromContext(c)
 }
 
-// Establish sets the user in the given context
+// Establish sets the user in the given context.
 func Establish() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		u := new(library.User)

--- a/router/pipeline.go
+++ b/router/pipeline.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-vela/worker/api"
 )
 
+// nolint: godot // ignore comment ending in period
+//
 // PipelineHandlers extends the provided base router group
 // by adding a collection of endpoints for handling
 // pipeline related requests.

--- a/router/repo.go
+++ b/router/repo.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-vela/worker/api"
 )
 
+// nolint: godot // ignore comment ending in period
+//
 // RepoHandlers extends the provided base router group
 // by adding a collection of endpoints for handling
 // repo related requests.


### PR DESCRIPTION
Continuation of the efforts from https://github.com/go-vela/mock/pull/76 and https://github.com/go-vela/types/pull/122

* Updating the contributing guide to include fixing linter warnings if any are present
* Skipping the `dupl` and `lll` linters on `*_test.go` files
* Added `nolint` directives across the repo to address any current linter issues