### PR TITLE
chore: upgrade go-vela/pkg-executor on v0.7.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/gin-gonic/gin v1.6.3
-	github.com/go-vela/pkg-executor v0.7.4
+	github.com/go-vela/pkg-executor v0.7.5
 	github.com/go-vela/pkg-queue v0.7.4
-	github.com/go-vela/pkg-runtime v0.7.4
+	github.com/go-vela/pkg-runtime v0.7.5
 	github.com/go-vela/sdk-go v0.7.4
 	github.com/go-vela/types v0.7.4
 	github.com/joho/godotenv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -195,12 +195,12 @@ github.com/go-vela/compiler v0.7.4 h1:dJG5Qmq3eQrT+5TzrOhdWKCG9RjIXI0uKakGDAtwOc
 github.com/go-vela/compiler v0.7.4/go.mod h1:1l4DWOSHJMHVcmgq6P6PEDTQicI6KMtSn7GI8LmoJ+M=
 github.com/go-vela/mock v0.7.4 h1:YthX/HXq9796wUAd+LV++x1tHnUJoWQnKZw7Rupw54w=
 github.com/go-vela/mock v0.7.4/go.mod h1:MZBxR/A9ChWsHI/+b3NQPYF85VJqh6iYU47Wpoujjrk=
-github.com/go-vela/pkg-executor v0.7.4 h1:qAY+vywxDTKykIiQet1aZObXRWT45lc9JCBbSUbEFRs=
-github.com/go-vela/pkg-executor v0.7.4/go.mod h1:BHSNSW0RLcvmcRCLi+LtYH/bm3NSWYUldN12b4KOvlQ=
+github.com/go-vela/pkg-executor v0.7.5 h1:TgxmttiKPuSbgD6FordWxJR1O24K39xZZuLA8QWMdnA=
+github.com/go-vela/pkg-executor v0.7.5/go.mod h1:ea0p3zCXot/hUKBK8Jwxp7ZBzQdd0eIfcLK15fBQlVQ=
 github.com/go-vela/pkg-queue v0.7.4 h1:CVfygL8idPl6RuXevA5YrdyXjvkJpC4g7Pg06ltR0Dw=
 github.com/go-vela/pkg-queue v0.7.4/go.mod h1:9oe/qmuRaByQZdeedROATTqAMYZhoPgZC36EhN0753Q=
-github.com/go-vela/pkg-runtime v0.7.4 h1:uz9Zqub/YW9Tf/d2jnUc9fCv2fEGyjHMukzZ7yrRet4=
-github.com/go-vela/pkg-runtime v0.7.4/go.mod h1:CCY2iidKjW7Pte4quOG6Zn9Flx7OyV4uQEP0TM2Jj3I=
+github.com/go-vela/pkg-runtime v0.7.5 h1:Fickp6sVhLXLaselaDMBTGKrmXJ8Fjb2IpL+iESds2M=
+github.com/go-vela/pkg-runtime v0.7.5/go.mod h1:CCY2iidKjW7Pte4quOG6Zn9Flx7OyV4uQEP0TM2Jj3I=
 github.com/go-vela/sdk-go v0.7.4 h1:OXUR8LZzO8kBmNY3yRuFojcmjWaMoK1s2q5iIpu5vhg=
 github.com/go-vela/sdk-go v0.7.4/go.mod h1:I1K3LpWOnfsJUhHXJf7DpwR9zVz4h65hRXzQ5IOxPuo=
 github.com/go-vela/types v0.7.4 h1:iVz1kDS/uvkOoridyyt0bTZ5tG2j3QYx25rbyFdu35M=


### PR DESCRIPTION
Related to https://github.com/go-vela/pkg-executor/pull/152 and https://github.com/go-vela/pkg-runtime/pull/115.

This is a backport of https://github.com/go-vela/pkg-runtime/pull/114 for the `v0.7.x` release.

This pulls in the `v0.7.5` tag for the [go-vela/pkg-executor](https://github.com/go-vela/pkg-executor) codebase.