### PR TITLE
chore: update dependencies for types pr 175

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/gin-gonic/gin v1.7.1
-	github.com/go-vela/pkg-executor v0.7.5-0.20210428160348-6ebccf544f01
+	github.com/go-vela/pkg-executor v0.7.5-0.20210520193522-d81f17d4ed5c
 	github.com/go-vela/pkg-queue v0.7.5-0.20210402170103-bcd9ababfe88
 	github.com/go-vela/pkg-runtime v0.7.5-0.20210428154035-f007d6e59a10
 	github.com/go-vela/sdk-go v0.7.4
-	github.com/go-vela/types v0.7.4
+	github.com/go-vela/types v0.7.5-0.20210520185150-62027576a4ad
 	github.com/joho/godotenv v1.3.0
 	github.com/prometheus/client_golang v1.10.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/gin-gonic/gin v1.7.1
-	github.com/go-vela/pkg-executor v0.7.5-0.20210520193522-d81f17d4ed5c
+	github.com/go-vela/pkg-executor v0.7.5-0.20210521154632-d53be352df36
 	github.com/go-vela/pkg-queue v0.7.5-0.20210402170103-bcd9ababfe88
 	github.com/go-vela/pkg-runtime v0.7.5-0.20210428154035-f007d6e59a10
 	github.com/go-vela/sdk-go v0.7.4

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.38.2/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -232,8 +234,8 @@ github.com/go-vela/compiler v0.7.4/go.mod h1:1l4DWOSHJMHVcmgq6P6PEDTQicI6KMtSn7G
 github.com/go-vela/mock v0.7.4/go.mod h1:MZBxR/A9ChWsHI/+b3NQPYF85VJqh6iYU47Wpoujjrk=
 github.com/go-vela/mock v0.7.5-0.20210416160452-fa8721fcc6a1 h1:99+SdZ72L5vTDdB4MJShE0oa5W5rUeYens/W0vhOosM=
 github.com/go-vela/mock v0.7.5-0.20210416160452-fa8721fcc6a1/go.mod h1:mjLSUHXoCVEjlfAhMhqjQuwOr7ZLNGuOxOXvjK+79jE=
-github.com/go-vela/pkg-executor v0.7.5-0.20210428160348-6ebccf544f01 h1:8SHkOYqGff0Gvf1gX6EbBYmN4HzU+valzOkoJwWvJh8=
-github.com/go-vela/pkg-executor v0.7.5-0.20210428160348-6ebccf544f01/go.mod h1:UYQ4NJPVFqDMWNgi5XW52TqPQ0mAq7UEhSmf2uLA8bM=
+github.com/go-vela/pkg-executor v0.7.5-0.20210520193522-d81f17d4ed5c h1:LghjYaOt1l39wIhqJf1K/8ZG/qrdGi44Fff5VpkjKg0=
+github.com/go-vela/pkg-executor v0.7.5-0.20210520193522-d81f17d4ed5c/go.mod h1:GA88in6i9qfddO+Roc3WjH1yud+T34zAyz5NNNIEwx0=
 github.com/go-vela/pkg-queue v0.7.5-0.20210402170103-bcd9ababfe88 h1:/K6hmGkYfJKaGwH7uNHN8M1SP7crWxjS9cQrD7gx8kA=
 github.com/go-vela/pkg-queue v0.7.5-0.20210402170103-bcd9ababfe88/go.mod h1:AcS5EDcNHhoJbsJlxtOKesRJ79XUnE9kqnUJMnOJITY=
 github.com/go-vela/pkg-runtime v0.7.5-0.20210428154035-f007d6e59a10 h1:MijNDyaFrM5iygRc0wcdJt2IL6Krth2/GTT8ZBbZopg=
@@ -244,6 +246,8 @@ github.com/go-vela/server v0.7.5-0.20210323124812-0da2c57a87ff h1:1LT69ic6xXBKSi
 github.com/go-vela/server v0.7.5-0.20210323124812-0da2c57a87ff/go.mod h1:QCB02xu5y2OMSZMNOZAjyoT3j5O6zTlDSdR/lF4ajYI=
 github.com/go-vela/types v0.7.4 h1:iVz1kDS/uvkOoridyyt0bTZ5tG2j3QYx25rbyFdu35M=
 github.com/go-vela/types v0.7.4/go.mod h1:/IsyxCijlz8BArRxBfrfRv7BBe/hmJGtVWegkS3ooJU=
+github.com/go-vela/types v0.7.5-0.20210520185150-62027576a4ad h1:SAEQdnOTQegVClpCixxe6Qnt8EKntA0cNbTI7s9VF1k=
+github.com/go-vela/types v0.7.5-0.20210520185150-62027576a4ad/go.mod h1:tKk+FpEAv+BTMr9CL3Wed6tMy5IqyOCJpRTKZI88yDc=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -335,6 +339,8 @@ github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyyc
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
+github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
@@ -445,6 +451,8 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
+github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
@@ -470,6 +478,8 @@ github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJK
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/microcosm-cc/bluemonday v1.0.9 h1:dpCwruVKoyrULicJwhuY76jB+nIxRVKv/e248Vx/BXg=
+github.com/microcosm-cc/bluemonday v1.0.9/go.mod h1:B2riunDr9benLHghZB7hjIgdwSUzzs0pjCxFrWYEZFU=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
@@ -780,6 +790,8 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 h1:OgUuv8lsRpBibGNbSizVwKWlysjaNzmC9gYMhPVfqFM=
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210421230115-4e50805a0758 h1:aEpZnXcAmXkd6AvLb2OPt+EN1Zu/8Ne3pCqPjja5PXY=
+golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -860,6 +872,8 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEqqNCi8rreOZnNrbqcIY=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe h1:WdX7u8s3yOigWAhHEaDl8r9G+4XwFQEQFtBMYyN+kXQ=
+golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
@@ -873,6 +887,8 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/go-vela/compiler v0.7.4/go.mod h1:1l4DWOSHJMHVcmgq6P6PEDTQicI6KMtSn7G
 github.com/go-vela/mock v0.7.4/go.mod h1:MZBxR/A9ChWsHI/+b3NQPYF85VJqh6iYU47Wpoujjrk=
 github.com/go-vela/mock v0.7.5-0.20210416160452-fa8721fcc6a1 h1:99+SdZ72L5vTDdB4MJShE0oa5W5rUeYens/W0vhOosM=
 github.com/go-vela/mock v0.7.5-0.20210416160452-fa8721fcc6a1/go.mod h1:mjLSUHXoCVEjlfAhMhqjQuwOr7ZLNGuOxOXvjK+79jE=
-github.com/go-vela/pkg-executor v0.7.5-0.20210520193522-d81f17d4ed5c h1:LghjYaOt1l39wIhqJf1K/8ZG/qrdGi44Fff5VpkjKg0=
-github.com/go-vela/pkg-executor v0.7.5-0.20210520193522-d81f17d4ed5c/go.mod h1:GA88in6i9qfddO+Roc3WjH1yud+T34zAyz5NNNIEwx0=
+github.com/go-vela/pkg-executor v0.7.5-0.20210521154632-d53be352df36 h1:PRsZx/utUZKURUWhSqtw1lF/5jADxC8kNORjifq/gqU=
+github.com/go-vela/pkg-executor v0.7.5-0.20210521154632-d53be352df36/go.mod h1:GA88in6i9qfddO+Roc3WjH1yud+T34zAyz5NNNIEwx0=
 github.com/go-vela/pkg-queue v0.7.5-0.20210402170103-bcd9ababfe88 h1:/K6hmGkYfJKaGwH7uNHN8M1SP7crWxjS9cQrD7gx8kA=
 github.com/go-vela/pkg-queue v0.7.5-0.20210402170103-bcd9ababfe88/go.mod h1:AcS5EDcNHhoJbsJlxtOKesRJ79XUnE9kqnUJMnOJITY=
 github.com/go-vela/pkg-runtime v0.7.5-0.20210428154035-f007d6e59a10 h1:MijNDyaFrM5iygRc0wcdJt2IL6Krth2/GTT8ZBbZopg=


### PR DESCRIPTION
Dependency updates needed for https://github.com/go-vela/types/pull/175