### PR TITLE
feat: output version info to stdout

### DIFF
--- a/cmd/vela-worker/main.go
+++ b/cmd/vela-worker/main.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -34,6 +36,18 @@ func init() {
 }
 
 func main() {
+	// capture application version information
+	v := version.New()
+
+	// serialize the version information as pretty JSON
+	bytes, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	// output the version information to stdout
+	fmt.Fprintf(os.Stdout, "%s\n", string(bytes))
+
 	app := cli.NewApp()
 
 	// Worker Information
@@ -53,7 +67,7 @@ func main() {
 
 	app.Action = run
 	app.Compiled = time.Now()
-	app.Version = version.New().Semantic()
+	app.Version = v.Semantic()
 
 	// Worker Flags
 
@@ -61,7 +75,7 @@ func main() {
 
 	// Worker Start
 
-	err := app.Run(os.Args)
+	err = app.Run(os.Args)
 	if err != nil {
 		logrus.Fatal(err)
 	}


### PR DESCRIPTION
This updates the `github.com/go-vela/worker` app to output the version information to stdout on startup:

```sh
$ docker logs worker
{
  "canonical": "v0.8.1",
  "major": 0,
  "minor": 8,
  "patch": 1,
  "metadata": {
    "architecture": "amd64",
    "build_date": "2021-06-15T08:43:01Z",
    "compiler": "gc",
    "git_commit": "2685530895be807f8bccf675c478618ade728192",
    "go_version": "go1.16.5",
    "operating_system": "linux"
  }
}
{"code":"https://github.com/go-vela/worker/","docs":"https://go-vela.github.io/docs/concepts/infrastructure/worker/","level":"info","msg":"Vela Worker","registry":"https://hub.docker.com/r/target/vela-worker/","time":"2021-06-15T13:43:42Z"}
<more logs>
```