### PR TITLE
fix(register): handle nil response

### DIFF
--- a/cmd/vela-worker/register.go
+++ b/cmd/vela-worker/register.go
@@ -18,12 +18,16 @@ func (w *Worker) checkIn(config *library.Worker) error {
 	logrus.Infof("retrieving worker %s from the server", config.GetHostname())
 	_, resp, err := w.VelaClient.Worker.Get(config.GetHostname())
 	if err != nil {
+		respErr := fmt.Errorf("unable to retrieve worker %s from the server: %v", config.GetHostname(), err)
+		if resp == nil {
+			return respErr
+		}
 		// if we receive a 404 the worker needs to be registered
 		if resp.StatusCode == http.StatusNotFound {
 			return w.register(config)
 		}
 
-		return fmt.Errorf("unable to retrieve worker %s from the server: %v", config.GetHostname(), err)
+		return respErr
 	}
 
 	// if we were able to GET the worker, update it


### PR DESCRIPTION
Resolves the following panic we were encountering within production:

```
/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x66
created by golang.org/x/sync/errgroup.(*Group).Go
/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x59
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000210e40, 0xc000210f00)
/__w/worker/worker/cmd/vela-worker/operate.go:59 +0x191
main.(*Worker).operate.func1(0x0, 0x0)
/__w/worker/worker/cmd/vela-worker/register.go:22 +0x146
main.(*Worker).checkIn(0xc00031fd40, 0xc0000c2900, 0x2b3da20, 0x0)
goroutine 48 [running]:
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18bf986]
panic: runtime error: invalid memory address or nil pointer dereference
```