### PR TITLE
fix: compare time chunks against zero

### DIFF
--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -256,11 +256,8 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 					return
 				// channel is not closed
 				default:
-					// get the current size of log data
-					size := len(_log.GetData())
-
 					// update the existing log with the new bytes if there is new data to add
-					if len(logs.Bytes()) > size {
+					if len(logs.Bytes()) > 0 {
 						logger.Trace(logs.String())
 
 						// update the existing log with the new bytes

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -305,11 +305,8 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 					return
 				// channel is not closed
 				default:
-					// get the current size of log data
-					size := len(_log.GetData())
-
 					// update the existing log with the new bytes if there is new data to add
-					if len(logs.Bytes()) > size {
+					if len(logs.Bytes()) > 0 {
 						logger.Trace(logs.String())
 
 						// update the existing log with the new bytes


### PR DESCRIPTION
fixes a bug in the linux executor where timed chunks are not written until the buffer becomes larger than the size of the log itself.