### PR TITLE
fix: local setup with server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@
 # These are used by the ui service
 # defined in the docker compose stack
 
-# customize the location where you want users to provide feedack
+# customize the location where you want users to provide feedback
 #
 # default: https://github.com/go-vela/ui/issues/new
 # VELA_FEEDBACK_URL=
@@ -44,10 +44,10 @@ VELA_API=http://localhost:8080
 # github web url (only required if using GitHub Enterprise)
 #
 # default: https://github.com
-# VELA_SOURCE_ADDR=
+# VELA_SCM_ADDR=
 
 # github client id from oauth application
-VELA_SOURCE_CLIENT=
+VELA_SCM_CLIENT=
 
 # github client secret from oauth application
-VELA_SOURCE_SECRET=
+VELA_SCM_SECRET=

--- a/DOCS.md
+++ b/DOCS.md
@@ -38,7 +38,7 @@ cd $HOME/go-vela/worker
 
 ```bash
 # add Github Enterprise Web URL to local `.env` file for `docker-compose`
-echo "VELA_SOURCE_ADDR=<GitHub Enterprise Web URL>" >> .env
+echo "VELA_SCM_ADDR=<GitHub Enterprise Web URL>" >> .env
 ```
 
 * Create an [OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) and obtain secrets for local development:
@@ -50,10 +50,10 @@ echo "VELA_SOURCE_ADDR=<GitHub Enterprise Web URL>" >> .env
 
 ```bash
 # add Github Client ID to local `.env` file for `docker-compose`
-echo "VELA_SOURCE_CLIENT=<Github OAuth Client ID>" >> .env
+echo "VELA_SCM_CLIENT=<Github OAuth Client ID>" >> .env
 
 # add Github Client Secret to local `.env` file for `docker-compose`
-echo "VELA_SOURCE_SECRET=<Github OAuth Client Secret>" >> .env
+echo "VELA_SCM_SECRET=<Github OAuth Client Secret>" >> .env
 ```
 
 ## Start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,8 @@ services:
       QUEUE_DRIVER: redis
       QUEUE_ADDR: 'redis://redis:6379'
       QUEUE_ROUTES: 'docker,local,docker:local'
-      SOURCE_DRIVER: github
-      SOURCE_CONTEXT: 'continuous-integration/vela'
+      SCM_DRIVER: github
+      SCM_CONTEXT: 'continuous-integration/vela'
       SECRET_VAULT: 'true'
       SECRET_VAULT_ADDR: 'http://vault:8200'
       SECRET_VAULT_TOKEN: vela


### PR DESCRIPTION
Related to https://github.com/go-vela/server/pull/536

This updates any references of `SOURCE_*` -> `SCM_*` based off the above change.