### PR TITLE
fix(docker): pulling images without output

### DIFF
--- a/runtime/docker/image.go
+++ b/runtime/docker/image.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -48,6 +49,12 @@ func (c *client) CreateImage(ctx context.Context, ctn *pipeline.Container) error
 	if logrus.GetLevel() == logrus.TraceLevel {
 		// copy output from image pull to standard output
 		_, err = io.Copy(os.Stdout, reader)
+		if err != nil {
+			return err
+		}
+	} else {
+		// discard output from image pull
+		_, err = io.Copy(ioutil.Discard, reader)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Based off of https://github.com/go-vela/worker/pull/246

An issue was discovered with the `target/vela-worker:latest` Docker image produced from this codebase.

We pulled that version into our lower environments today for testing and noticed a discrepancy:

![image](https://user-images.githubusercontent.com/10966923/146251929-ca99f533-27bc-42ce-a1b8-cfa66c0f3af6.png)

The issue seems specifically isolated to when the worker attempts to pull Docker images.

SEE EDIT - ~Thus far, was unsuccessful in reproducing locally but it could be related to us using an internal registry mirror.~ 

At any rate, was able to reproduce the issue on our internal infrastructure and this seems to resolve that issue.

## EDIT

Thanks to [a comment made](https://github.com/go-vela/worker/pull/253#issuecomment-995163389) by @wass3r, I was able to figure out how to reproduce it locally.

[In the above PR](https://github.com/go-vela/worker/pull/246), a change was made to ignore the output from the `docker pull` performed by a worker.

The exception to this, where you will see this output, is when the worker is setup with `trace` level logging:

https://github.com/go-vela/worker/blob/c123efa33438da8063df81189d0bb43fbe0a5504/runtime/docker/image.go#L47-L54

This change inadvertently introduced a bug when the worker attempts to fetch a new Docker image for a build.

You can reproduce this issue with the following steps:

1. Checkout to the `master` branch of this repository:

```shell
$ git checkout master
```

2. Remove `trace` level logging for the worker by removing or commenting out the following line:

https://github.com/go-vela/worker/blob/c123efa33438da8063df81189d0bb43fbe0a5504/docker-compose.yml#L29

3. Remove a Docker image from your local image cache so the worker is forced to pull it when a build runs:

```shell
$ docker rmi -f target/vela-git:v0.4.0
```

4. Start the [local Vela stack](https://github.com/go-vela/worker/blob/master/DOCS.md) via Docker-Compose.

5. Run a build locally and watch the error message above be displayed in the Vela UI.
