### PR TITLE
fix(step): add catch block for disallowed secrets

### DIFF
--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -464,15 +464,15 @@ func getSecretValues(ctn *pipeline.Container) []string {
 	secretValues := []string{}
 	// gather secrets' values from the environment map for masking
 	for _, secret := range ctn.Secrets {
-		s := ctn.Environment[strings.ToUpper(secret.Target)]
+		// capture secret from environment
+		s, ok := ctn.Environment[strings.ToUpper(secret.Target)]
+		if !ok {
+			continue
+		}
 		// handle multi line secrets from files
 		s = strings.ReplaceAll(s, "\n", " ")
 
-		// drop any trailing spaces
-		if strings.HasSuffix(s, " ") {
-			s = s[:(len(s) - 1)]
-		}
-		secretValues = append(secretValues, s)
+		secretValues = append(secretValues, strings.TrimSuffix(s, " "))
 	}
 	return secretValues
 }

--- a/executor/linux/step_test.go
+++ b/executor/linux/step_test.go
@@ -570,6 +570,10 @@ func TestLinux_getSecretValues(t *testing.T) {
 						Source: "someOtherSource",
 						Target: "secret_password",
 					},
+					{
+						Source: "disallowedSecret",
+						Target: "cannot_find",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
When pulling secret values to be masked, we need to catch the instance where a secret is not allowed for that event. Otherwise, when the map does not find the secret, it returns an empty string. 