### PR TITLE
fix(logs/secrets): check for disallowed/non-existent secrets

### DIFF
--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -472,11 +472,7 @@ func getSecretValues(ctn *pipeline.Container) []string {
 		// handle multi line secrets from files
 		s = strings.ReplaceAll(s, "\n", " ")
 
-		// drop any trailing spaces
-		if strings.HasSuffix(s, " ") {
-			s = s[:(len(s) - 1)]
-		}
-		secretValues = append(secretValues, s)
+		secretValues = append(secretValues, strings.TrimSuffix(s, " "))
 	}
 	return secretValues
 }

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -464,7 +464,11 @@ func getSecretValues(ctn *pipeline.Container) []string {
 	secretValues := []string{}
 	// gather secrets' values from the environment map for masking
 	for _, secret := range ctn.Secrets {
-		s := ctn.Environment[strings.ToUpper(secret.Target)]
+		// capture secret from environment
+		s, ok := ctn.Environment[strings.ToUpper(secret.Target)]
+		if !ok {
+			continue
+		}
 		// handle multi line secrets from files
 		s = strings.ReplaceAll(s, "\n", " ")
 

--- a/executor/linux/step_test.go
+++ b/executor/linux/step_test.go
@@ -570,6 +570,10 @@ func TestLinux_getSecretValues(t *testing.T) {
 						Source: "someOtherSource",
 						Target: "secret_password",
 					},
+					{
+						Source: "disallowedSecret",
+						Target: "cannot_find",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Backport for patch release (v0.12.1). 

When users inject secrets for a container that are not allowed for the event or simply do not exist, the `getSecretValues` function would set them to an empty string, resulting in ugly logs. 

Earlier, merged PR: https://github.com/go-vela/worker/pull/272