### PR TITLE
enhance(http): add retry client

### DIFF
--- a/cmd/vela-worker/client.go
+++ b/cmd/vela-worker/client.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"github.com/go-vela/sdk-go/vela"
+	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/sirupsen/logrus"
 )
@@ -13,11 +14,15 @@ import (
 // helper function to setup the queue from the CLI arguments.
 func setupClient(s *Server) (*vela.Client, error) {
 	logrus.Debug("creating vela client from worker configuration")
+	// create client to retryable http calls
+	retryClient := retryablehttp.NewClient()
+	// set logger to nil to avoid spam
+	retryClient.Logger = nil
 
 	// create a new Vela client from the server configuration
 	//
 	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#NewClient
-	vela, err := vela.NewClient(s.Address, "", nil)
+	vela, err := vela.NewClient(s.Address, "", retryClient.StandardClient())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This aims to hopefully help workaround intermittent errors returned by the Vela by adding a retryable http client created by [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp). Do folks think we should override the [default retry check](https://github.com/hashicorp/go-retryablehttp/blob/master/client.go#L386) to allow retrying on `context.DeadlineExceeded` errors? I ask this since prior connectivity failures reported like https://github.com/go-vela/community/issues/434 specifically had deadline exceeded errors.