### PR TITLE
fix(kubernetes): Coordinate Runtime's RunContainer/TailContainer via a channel

### DIFF
--- a/executor/engine.go
+++ b/executor/engine.go
@@ -70,7 +70,7 @@ type Engine interface {
 	ExecService(context.Context, *pipeline.Container) error
 	// StreamService defines a function that
 	// tails the output for a service.
-	StreamService(context.Context, *pipeline.Container) error
+	StreamService(context.Context, *pipeline.Container, chan struct{}) error
 	// DestroyService defines a function that
 	// cleans up the service after execution.
 	DestroyService(context.Context, *pipeline.Container) error
@@ -103,7 +103,7 @@ type Engine interface {
 	ExecStep(context.Context, *pipeline.Container) error
 	// StreamStep defines a function that
 	// tails the output for a step.
-	StreamStep(context.Context, *pipeline.Container) error
+	StreamStep(context.Context, *pipeline.Container, chan struct{}) error
 	// DestroyStep defines a function that
 	// cleans up the step after execution.
 	DestroyStep(context.Context, *pipeline.Container) error

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -523,6 +523,11 @@ func TestLinux_Secret_stream(t *testing.T) {
 		},
 	}
 
+	// these tests use docker runtime, so simulate docker runtime behavior by
+	// passing a closed channel to let TailContainer start right away
+	runtimeChannel := make(chan struct{})
+	close(runtimeChannel)
+
 	// run tests
 	for _, test := range tests {
 		_engine, err := New(
@@ -540,7 +545,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 		// add init container info to client
 		_ = _engine.CreateBuild(context.Background())
 
-		err = _engine.secret.stream(context.Background(), test.container)
+		err = _engine.secret.stream(context.Background(), test.container, runtimeChannel)
 
 		if test.failure {
 			if err == nil {

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -136,12 +136,23 @@ func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error
 	// https://pkg.go.dev/github.com/go-vela/worker/internal/service#Snapshot
 	defer func() { service.Snapshot(ctn, c.build, c.Vela, c.Logger, c.repo, _service) }()
 
-	logger.Debug("running container")
-	// run the runtime container
-	err = c.Runtime.RunContainer(ctx, ctn, c.pipeline)
-	if err != nil {
-		return err
-	}
+	// create a channel so Runtime can optionally synchronize RunContainer and TailContainer
+	runtimeChannel := make(chan struct{})
+
+	// create an error group with the parent context
+	//
+	// https://pkg.go.dev/golang.org/x/sync/errgroup?tab=doc#WithContext
+	run, runCtx := errgroup.WithContext(ctx)
+
+	run.Go(func() error {
+		logger.Debug("running container")
+		// run the runtime container
+		err = c.Runtime.RunContainer(runCtx, ctn, c.pipeline, runtimeChannel)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 
 	// create an error group with the parent context
 	//
@@ -151,13 +162,18 @@ func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error
 	logs.Go(func() error {
 		logger.Debug("streaming logs for container")
 		// stream logs from container
-		err := c.StreamService(logCtx, ctn)
+		err := c.StreamService(logCtx, ctn, runtimeChannel)
 		if err != nil {
 			logger.Error(err)
 		}
-
 		return nil
 	})
+
+	// ensure that RunContainer has finished requesting the runtime container
+	err = run.Wait()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -165,7 +181,7 @@ func (c *client) ExecService(ctx context.Context, ctn *pipeline.Container) error
 // StreamService tails the output for a service.
 //
 // nolint: funlen // ignore function length
-func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) error {
+func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container, runtimeChannel chan struct{}) error {
 	// update engine logger with service metadata
 	//
 	// https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry.WithField
@@ -181,7 +197,7 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 
 	defer func() {
 		// tail the runtime container
-		rc, err := c.Runtime.TailContainer(ctx, ctn)
+		rc, err := c.Runtime.TailContainer(ctx, ctn, runtimeChannel)
 		if err != nil {
 			logger.Errorf("unable to tail container output for upload: %v", err)
 
@@ -221,7 +237,7 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 
 	logger.Debug("tailing container")
 	// tail the runtime container
-	rc, err := c.Runtime.TailContainer(ctx, ctn)
+	rc, err := c.Runtime.TailContainer(ctx, ctn, runtimeChannel)
 	if err != nil {
 		return err
 	}

--- a/executor/linux/service_test.go
+++ b/executor/linux/service_test.go
@@ -352,6 +352,11 @@ func TestLinux_StreamService(t *testing.T) {
 		},
 	}
 
+	// these tests use docker runtime, so simulate docker runtime behavior by
+	// passing a closed channel to let TailContainer start right away
+	runtimeChannel := make(chan struct{})
+	close(runtimeChannel)
+
 	// run tests
 	for _, test := range tests {
 		_engine, err := New(
@@ -371,7 +376,7 @@ func TestLinux_StreamService(t *testing.T) {
 			_engine.serviceLogs.Store(test.container.ID, new(library.Log))
 		}
 
-		err = _engine.StreamService(context.Background(), test.container)
+		err = _engine.StreamService(context.Background(), test.container, runtimeChannel)
 
 		if test.failure {
 			if err == nil {

--- a/executor/linux/step_test.go
+++ b/executor/linux/step_test.go
@@ -397,6 +397,11 @@ func TestLinux_StreamStep(t *testing.T) {
 		},
 	}
 
+	// these tests use docker runtime, so simulate docker runtime behavior by
+	// passing a closed channel to let TailContainer start right away
+	runtimeChannel := make(chan struct{})
+	close(runtimeChannel)
+
 	// run tests
 	for _, test := range tests {
 		_engine, err := New(
@@ -417,7 +422,7 @@ func TestLinux_StreamStep(t *testing.T) {
 			_engine.stepLogs.Store(test.container.ID, new(library.Log))
 		}
 
-		err = _engine.StreamStep(context.Background(), test.container)
+		err = _engine.StreamStep(context.Background(), test.container, runtimeChannel)
 
 		if test.failure {
 			if err == nil {

--- a/executor/local/service_test.go
+++ b/executor/local/service_test.go
@@ -277,6 +277,11 @@ func TestLocal_StreamService(t *testing.T) {
 		},
 	}
 
+	// these tests use docker runtime, so simulate docker runtime behavior by
+	// passing a closed channel to let TailContainer start right away
+	runtimeChannel := make(chan struct{})
+	close(runtimeChannel)
+
 	// run tests
 	for _, test := range tests {
 		_engine, err := New(
@@ -290,7 +295,7 @@ func TestLocal_StreamService(t *testing.T) {
 			t.Errorf("unable to create executor engine: %v", err)
 		}
 
-		err = _engine.StreamService(context.Background(), test.container)
+		err = _engine.StreamService(context.Background(), test.container, runtimeChannel)
 
 		if test.failure {
 			if err == nil {

--- a/executor/local/step_test.go
+++ b/executor/local/step_test.go
@@ -326,6 +326,11 @@ func TestLocal_StreamStep(t *testing.T) {
 		},
 	}
 
+	// these tests use docker runtime, so simulate docker runtime behavior by
+	// passing a closed channel to let TailContainer start right away
+	runtimeChannel := make(chan struct{})
+	close(runtimeChannel)
+
 	// run tests
 	for _, test := range tests {
 		_engine, err := New(
@@ -339,7 +344,7 @@ func TestLocal_StreamStep(t *testing.T) {
 			t.Errorf("unable to create executor engine: %v", err)
 		}
 
-		err = _engine.StreamStep(context.Background(), test.container)
+		err = _engine.StreamStep(context.Background(), test.container, runtimeChannel)
 
 		if test.failure {
 			if err == nil {

--- a/runtime/docker/container_test.go
+++ b/runtime/docker/container_test.go
@@ -208,7 +208,9 @@ func TestDocker_RunContainer(t *testing.T) {
 			_engine.config.Volumes = test.volumes
 		}
 
-		err = _engine.RunContainer(context.Background(), test.container, test.pipeline)
+		runtimeChannel := make(chan struct{})
+
+		err = _engine.RunContainer(context.Background(), test.container, test.pipeline, runtimeChannel)
 
 		if test.failure {
 			if err == nil {
@@ -330,9 +332,13 @@ func TestDocker_TailContainer(t *testing.T) {
 		},
 	}
 
+	// pass a closed channel to let TailContainer start right away
+	runtimeChannel := make(chan struct{})
+	close(runtimeChannel)
+
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.TailContainer(context.Background(), test.container)
+		_, err = _engine.TailContainer(context.Background(), test.container, runtimeChannel)
 
 		if test.failure {
 			if err == nil {

--- a/runtime/engine.go
+++ b/runtime/engine.go
@@ -46,13 +46,13 @@ type Engine interface {
 	RemoveContainer(context.Context, *pipeline.Container) error
 	// RunContainer defines a function that creates
 	// and starts the pipeline container.
-	RunContainer(context.Context, *pipeline.Container, *pipeline.Build) error
+	RunContainer(context.Context, *pipeline.Container, *pipeline.Build, chan struct{}) error
 	// SetupContainer defines a function that prepares
 	// the image for the pipeline container.
 	SetupContainer(context.Context, *pipeline.Container) error
 	// TailContainer defines a function that captures
 	// the logs on the pipeline container.
-	TailContainer(context.Context, *pipeline.Container) (io.ReadCloser, error)
+	TailContainer(context.Context, *pipeline.Container, chan struct{}) (io.ReadCloser, error)
 	// WaitContainer defines a function that blocks
 	// until the pipeline container completes.
 	WaitContainer(context.Context, *pipeline.Container) error

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -115,6 +115,10 @@ func TestKubernetes_RunContainer(t *testing.T) {
 		},
 	}
 
+	// pass a closed channel to let RunContainer start right away
+	runtimeChannel := make(chan struct{})
+	close(runtimeChannel)
+
 	// run tests
 	for _, test := range tests {
 		_engine, err := NewMock(test.pod)
@@ -126,7 +130,7 @@ func TestKubernetes_RunContainer(t *testing.T) {
 			_engine.config.Volumes = test.volumes
 		}
 
-		err = _engine.RunContainer(context.Background(), test.container, test.pipeline)
+		err = _engine.RunContainer(context.Background(), test.container, test.pipeline, runtimeChannel)
 
 		if test.failure {
 			if err == nil {


### PR DESCRIPTION
The Kubernetes runtime needs to start streaming logs before the container starts.
The Docker runtime needs to start the container before streaming longs.
With both running in goroutines, the Runtime can block one method until the other completes in whichever order makes sense for that Runtime.

Alternate to #277
