### PR TITLE
refactor(logs): Replace "Pulling" with "Preparing" in init step logs

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -151,7 +151,7 @@ func (c *client) PlanBuild(ctx context.Context) error {
 	// update the init log with progress
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	_log.AppendData([]byte("> Pulling secrets...\n"))
+	_log.AppendData([]byte("> Preparing secrets...\n"))
 
 	// iterate through each secret provided in the pipeline
 	for _, secret := range c.pipeline.Secrets {
@@ -231,7 +231,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	// update the init log with progress
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	_log.AppendData([]byte("> Pulling service images...\n"))
+	_log.AppendData([]byte("> Preparing service images...\n"))
 
 	// create the services for the pipeline
 	for _, s := range c.pipeline.Services {
@@ -262,7 +262,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	// update the init log with progress
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	_log.AppendData([]byte("> Pulling stage images...\n"))
+	_log.AppendData([]byte("> Preparing stage images...\n"))
 
 	// create the stages for the pipeline
 	for _, s := range c.pipeline.Stages {
@@ -284,7 +284,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	// update the init log with progress
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	_log.AppendData([]byte("> Pulling step images...\n"))
+	_log.AppendData([]byte("> Preparing step images...\n"))
 
 	// create the steps for the pipeline
 	for _, s := range c.pipeline.Steps {
@@ -317,7 +317,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	// update the init log with progress
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	_log.AppendData([]byte("> Pulling secret images...\n"))
+	_log.AppendData([]byte("> Preparing secret images...\n"))
 
 	// create the secrets for the pipeline
 	for _, s := range c.pipeline.Secrets {

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -31,7 +31,7 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 	// update the init log with progress
 	//
 	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
-	_log.AppendData([]byte(fmt.Sprintf("> Pulling step images for stage %s...\n", s.Name)))
+	_log.AppendData([]byte(fmt.Sprintf("> Preparing step images for stage %s...\n", s.Name)))
 
 	// create the steps for the stage
 	for _, _step := range s.Steps {

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -162,7 +162,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	}
 
 	// output init progress to stdout
-	fmt.Fprintln(os.Stdout, _pattern, "> Pulling service images...")
+	fmt.Fprintln(os.Stdout, _pattern, "> Preparing service images...")
 
 	// create the services for the pipeline
 	for _, _service := range c.pipeline.Services {
@@ -187,7 +187,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	}
 
 	// output init progress to stdout
-	fmt.Fprintln(os.Stdout, _pattern, "> Pulling stage images...")
+	fmt.Fprintln(os.Stdout, _pattern, "> Preparing stage images...")
 
 	// create the stages for the pipeline
 	for _, _stage := range c.pipeline.Stages {
@@ -206,7 +206,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 	}
 
 	// output init progress to stdout
-	fmt.Fprintln(os.Stdout, _pattern, "> Pulling step images...")
+	fmt.Fprintln(os.Stdout, _pattern, "> Preparing step images...")
 
 	// create the steps for the pipeline
 	for _, _step := range c.pipeline.Steps {

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -23,7 +23,7 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 	_pattern := fmt.Sprintf(stagePattern, c.init.Name, c.init.Name)
 
 	// output init progress to stdout
-	fmt.Fprintln(os.Stdout, _pattern, "> Pulling step images for stage", s.Name, "...")
+	fmt.Fprintln(os.Stdout, _pattern, "> Preparing step images for stage", s.Name, "...")
 
 	// create the steps for the stage
 	for _, _step := range s.Steps {


### PR DESCRIPTION
`Pulling` is a Docker-specific term that does not apply to the Kubernetes runtime. `Preparing` is more generic and can apply to both. So, replace `Pulling` with `Preparing` in the logs.
