### PR TITLE
chore: Always make the built binary executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ build:
 		-ldflags '${LD_FLAGS}' \
 		-o release/vela-worker \
 		github.com/go-vela/worker/cmd/vela-worker
+	@chmod +x release/vela-worker
 
 # The `build-static` target is intended to compile
 # the Go source code into a statically linked binary.
@@ -145,6 +146,7 @@ build-static:
 		-ldflags '-s -w -extldflags "-static" ${LD_FLAGS}' \
 		-o release/vela-worker \
 		github.com/go-vela/worker/cmd/vela-worker
+	@chmod +x release/vela-worker
 
 # The `build-static-ci` target is intended to compile
 # the Go source code into a statically linked binary
@@ -159,6 +161,7 @@ build-static-ci:
 		-ldflags '-s -w -extldflags "-static" ${LD_FLAGS}' \
 		-o release/vela-worker \
 		github.com/go-vela/worker/cmd/vela-worker
+	@chmod +x release/vela-worker
 
 # The `check` target is intended to output all
 # dependencies from the Go module that need updates.


### PR DESCRIPTION
I keep forgetting to make the binary executable after I build with `make build-static` and before I build my new docker image.
This PR should save me from myself.
