### PR TITLE
refactor(kubernetes): manage log streaming at pod-level

### DIFF
--- a/cmd/vela-worker/run.go
+++ b/cmd/vela-worker/run.go
@@ -111,6 +111,7 @@ func run(c *cli.Context) error {
 				PodsTemplateFile: c.Path("runtime.pods-template-file"),
 				HostVolumes:      c.StringSlice("runtime.volumes"),
 				PrivilegedImages: c.StringSlice("runtime.privileged-images"),
+				MaxLogSize:       c.Uint("executor.max_log_size"),
 			},
 			// queue configuration
 			Queue: &queue.Setup{

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -398,6 +398,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 			if c.maxLogSize > 0 && uint(len(_log.GetData())) >= c.maxLogSize {
 				logger.Trace("maximum log size reached")
 
+				logs.Write([]byte("LOGS TRUNCATED: Vela Executor MaxLogSize exceeded.\n"))
 				break
 			}
 		}

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -399,6 +399,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 				logger.Trace("maximum log size reached")
 
 				logs.Write([]byte("LOGS TRUNCATED: Vela Executor MaxLogSize exceeded.\n"))
+
 				break
 			}
 		}

--- a/internal/log/buffer.go
+++ b/internal/log/buffer.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package log
+
+// This file is based on https://stackoverflow.com/a/44322300 .
+
+import (
+	"io"
+	"sync"
+)
+
+// Buffer is an in-memory log cache that allows multiple reads.
+type Buffer interface {
+	io.Writer
+	// NewReader returns an io.Reader that reads the Buffer from the beginning.
+	NewReader() io.Reader
+}
+
+// buffer implements the in-memory log cache Buffer.
+type buffer struct {
+	// data contains the log cache
+	data [][]byte
+	// RWMutex is required to ensure safe write and read from the same cache.
+	sync.RWMutex
+}
+
+// Write writes to the shared Buffer cache, implementing io.Writer.
+// This manages thread safety using a sync.RWMutex.
+func (b *buffer) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	// Cannot retain p, so we must copy it:
+	p2 := make([]byte, len(p))
+	copy(p2, p)
+	b.Lock()
+	b.data = append(b.data, p2)
+	b.Unlock()
+	return len(p), nil
+}
+
+// bufferReader reads from buffer from the beginning without consuming its contents.
+// bufferReader implements the io.Reader returned by buffer.NewReader().
+type bufferReader struct {
+	buf   *buffer // buffer we read from
+	index int     // next slice index
+	data  []byte  // current data slice to serve
+}
+
+// Read reads from the shared Buffer cache, implementing io.Writer.
+// This manages thread safety using a sync.RWMutex.
+func (br *bufferReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	// Do we have data to send?
+	if len(br.data) == 0 {
+		buf := br.buf
+		buf.RLock()
+		if br.index < len(buf.data) {
+			br.data = buf.data[br.index]
+			br.index++
+		}
+		buf.RUnlock()
+	}
+	if len(br.data) == 0 {
+		return 0, io.EOF
+	}
+
+	n = copy(p, br.data)
+	br.data = br.data[n:]
+	return n, nil
+}
+
+// NewReader returns an io.Reader that reads from the shared buffer
+// from the beginning without consuming its contents.
+func (b *buffer) NewReader() io.Reader {
+	return &bufferReader{buf: b}
+}
+
+// NewBuffer creates and returns a new empty Buffer ready for Read and Write.
+func NewBuffer() Buffer {
+	return &buffer{}
+}

--- a/internal/log/buffer.go
+++ b/internal/log/buffer.go
@@ -40,6 +40,7 @@ func (b *buffer) Write(p []byte) (n int, err error) {
 	b.Lock()
 	b.data = append(b.data, p2)
 	b.Unlock()
+
 	return len(p), nil
 }
 
@@ -47,6 +48,7 @@ func (b *buffer) Write(p []byte) (n int, err error) {
 func (b *buffer) Length() (n int) {
 	b.RLock()
 	defer b.RUnlock()
+
 	return len(b.data)
 }
 
@@ -74,12 +76,14 @@ func (br *bufferReader) Read(p []byte) (n int, err error) {
 		}
 		buf.RUnlock()
 	}
+
 	if len(br.data) == 0 {
 		return 0, io.EOF
 	}
 
 	n = copy(p, br.data)
 	br.data = br.data[n:]
+
 	return n, nil
 }
 

--- a/internal/log/buffer.go
+++ b/internal/log/buffer.go
@@ -16,6 +16,8 @@ type Buffer interface {
 	io.Writer
 	// NewReader returns an io.Reader that reads the Buffer from the beginning.
 	NewReader() io.Reader
+	// Length returns the current length of buffer contents.
+	Length() int
 }
 
 // buffer implements the in-memory log cache Buffer.
@@ -39,6 +41,13 @@ func (b *buffer) Write(p []byte) (n int, err error) {
 	b.data = append(b.data, p2)
 	b.Unlock()
 	return len(p), nil
+}
+
+// Length returns the current length of buffer contents.
+func (b *buffer) Length() (n int) {
+	b.RLock()
+	defer b.RUnlock()
+	return len(b.data)
 }
 
 // bufferReader reads from buffer from the beginning without consuming its contents.

--- a/internal/log/doc.go
+++ b/internal/log/doc.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// Package log provides the ability for Vela to
+// cache and stream container logs without consuming
+// the cached logs.
+//
+// Usage:
+//
+// 	import "github.com/go-vela/worker/internal/log"
+package log

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -7,7 +7,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/tools/cache"
 	"time"
 
 	"github.com/go-vela/types/pipeline"
@@ -15,6 +14,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	// The k8s libraries have some quirks around yaml marshaling (see opts.go).
 	// So, just use the same library for all kubernetes-related YAML.
@@ -127,6 +127,7 @@ func (c *client) SetupBuild(ctx context.Context, b *pipeline.Build) error {
 		}
 	}
 
+	// initialize the PodTracker now that we have a Pod for it to track
 	tracker, err := NewPodTracker(c.Logger, c.Kubernetes, c.Pod, time.Second*30)
 	if err != nil {
 		return err
@@ -192,7 +193,7 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 		}
 	}
 
-	// Populate the PodTracker caches
+	// Populate the PodTracker caches before creating the pipeline pod
 	c.PodTracker.Start(ctx.Done())
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.PodTracker.PodSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -195,6 +195,7 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 
 	// Populate the PodTracker caches before creating the pipeline pod
 	c.PodTracker.Start(ctx.Done())
+
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.PodTracker.PodSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -192,14 +192,6 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 		}
 	}
 
-	// TODO: use these to start streaming logs before TailContainer is called
-	// Add the ResourceEventHandler
-	//c.PodTracker.AddPodInformerEventHandler(cache.ResourceEventHandlerFuncs{
-	//	AddFunc:    func(new interface{}) {},
-	//	UpdateFunc: func(old, new interface{}) {},
-	//	DeleteFunc: func(old interface{}) {},
-	//})
-
 	// Populate the PodTracker caches
 	c.PodTracker.Start(ctx.Done())
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.PodTracker.PodSynced); !ok {

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -194,7 +194,7 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 	}
 
 	// Populate the PodTracker caches before creating the pipeline pod
-	c.PodTracker.Start(ctx.Done())
+	c.PodTracker.Start(ctx)
 
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.PodTracker.PodSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -128,7 +128,7 @@ func (c *client) SetupBuild(ctx context.Context, b *pipeline.Build) error {
 	}
 
 	// initialize the PodTracker now that we have a Pod for it to track
-	tracker, err := NewPodTracker(c.Logger, c.Kubernetes, c.Pod, time.Second*30)
+	tracker, err := newPodTracker(c.Logger, c.Kubernetes, c.Pod, time.Second*30)
 	if err != nil {
 		return err
 	}

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -194,6 +194,9 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 		}
 	}
 
+	// setup containerTeachers now that all containers are defined.
+	c.PodTracker.TrackContainers(c.Pod.Spec.Containers)
+
 	// Populate the PodTracker caches before creating the pipeline pod
 	c.PodTracker.Start(ctx)
 

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -82,6 +82,7 @@ func (c *client) SetupBuild(ctx context.Context, b *pipeline.Build) error {
 	// https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1?tab=doc#ObjectMeta
 	c.Pod.ObjectMeta = metav1.ObjectMeta{
 		Name:        b.ID,
+		Namespace:   c.config.Namespace, // this is used by the podTracker
 		Labels:      labels,
 		Annotations: c.PipelinePodTemplate.Metadata.Annotations,
 	}

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -198,7 +198,7 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 	c.PodTracker.TrackContainers(c.Pod.Spec.Containers)
 
 	// Populate the PodTracker caches before creating the pipeline pod
-	c.PodTracker.Start(ctx)
+	c.PodTracker.Start(ctx, c.config.maxLogSize)
 
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.PodTracker.PodSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -25,7 +25,7 @@ import (
 func (c *client) InspectBuild(ctx context.Context, b *pipeline.Build) ([]byte, error) {
 	c.Logger.Tracef("inspecting build pod for pipeline %s", b.ID)
 
-	output := []byte(fmt.Sprintf("> Inspecting pod for pipeline %s", b.ID))
+	output := []byte(fmt.Sprintf("> Inspecting pod for pipeline %s\n", b.ID))
 
 	// TODO: The environment gets populated in AssembleBuild, after InspectBuild runs.
 	//       But, we should make sure that secrets can't be leaked here anyway.

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -27,18 +27,8 @@ import (
 func (c *client) InspectContainer(ctx context.Context, ctn *pipeline.Container) error {
 	c.Logger.Tracef("inspecting container %s", ctn.ID)
 
-	// create options for getting the container
-	opts := metav1.GetOptions{}
-
-	// send API call to capture the container
-	//
-	// https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1?tab=doc#PodInterface
-	// nolint: contextcheck // ignore non-inherited new context
-	pod, err := c.Kubernetes.CoreV1().Pods(c.config.Namespace).Get(
-		context.Background(),
-		c.Pod.ObjectMeta.Name,
-		opts,
-	)
+	// get the pod from the local cache, which the Informer keeps up-to-date
+	pod, err := c.PodTracker.PodLister.Pods(c.config.Namespace).Get(c.Pod.ObjectMeta.Name)
 	if err != nil {
 		return err
 	}

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -230,7 +230,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 	}
 
 	// wrap the bytes.Reader in an io.NopCloser
-	logs = io.NopCloser(containerTracker.Logs())
+	logs = io.NopCloser(containerTracker.Logs.NewReader())
 
 	logsError := containerTracker.LogsError
 	// io.EOF means that all logs have been captured.
@@ -276,7 +276,7 @@ func (p podTracker) streamContainerLogs(ctx context.Context, ctnTracker *contain
 		defer stream.Close()
 
 		// save everything read from the stream to the logs cache.
-		tee := io.TeeReader(stream, ctnTracker.logs)
+		tee := io.TeeReader(stream, ctnTracker.Logs)
 		// create a reader that allows reading one line at a time
 		reader := bufio.NewReader(tee)
 
@@ -304,12 +304,12 @@ func (p podTracker) streamContainerLogs(ctx context.Context, ctnTracker *contain
 
 			// there are more logs to read
 			// check whether we've reached the maximum log size
-			if maxLogSize > 0 && uint(ctnTracker.logs.Length()) >= maxLogSize {
+			if maxLogSize > 0 && uint(ctnTracker.Logs.Length()) >= maxLogSize {
 				p.Logger.Trace("maximum log size reached")
 
 				ctnTracker.LogsError = ErrTruncatedLogs
 
-				_, err = ctnTracker.logs.Write([]byte("LOGS TRUNCATED: Vela Runtime MaxLogSize exceeded.\n"))
+				_, err = ctnTracker.Logs.Write([]byte("LOGS TRUNCATED: Vela Runtime MaxLogSize exceeded.\n"))
 				if err != nil {
 					p.Logger.Errorf("error adding log truncated message for %s, %v", p.TrackedPod, err)
 				}
@@ -319,7 +319,7 @@ func (p podTracker) streamContainerLogs(ctx context.Context, ctnTracker *contain
 		}
 
 		// check if we have container logs from the stream
-		if ctnTracker.logs.Length() > 0 {
+		if ctnTracker.Logs.Length() > 0 {
 			// no more logs to stream
 			return true, nil
 		}

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -356,7 +356,6 @@ func (p podTracker) inspectContainerStatuses(pod *v1.Pod) {
 			// if that is still needed, then we can add that check here
 			// or retrieve the pod with something like this in WaitContainer:
 			// c.PodTracker.PodLister.Pods(c.config.Namespace).Get(c.Pod.GetName())
-
 			tracker.terminatedOnce.Do(func() {
 				// let WaitContainer know the container is terminated
 				close(tracker.Terminated)

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -233,7 +233,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 
 	logsError := containerTracker.LogsError
 	// io.EOF means that all logs have been captured.
-	if logsError != nil && logsError != io.EOF {
+	if logsError != nil && logsError != io.EOF && logsError != TruncatedLogs {
 		// TODO: modify the executor to accept record partial logs before the failure
 		return logs, logsError
 	}
@@ -308,6 +308,7 @@ func (p podTracker) streamContainerLogs(ctx context.Context, ctnTracker *contain
 			if maxLogSize > 0 && uint(len(ctnTracker.logs)) >= maxLogSize {
 				p.Logger.Trace("maximum log size reached")
 
+				ctnTracker.LogsError = TruncatedLogs
 				ctnTracker.logs = append(ctnTracker.logs, []byte("LOGS TRUNCATED: Vela Runtime MaxLogSize exceeded.\n")...)
 				break
 			}

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -245,6 +245,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 // streamContainerLogs streams the logs to a cache up to a maxLogSize, restarting the stream as needed.
 // streamContainerLogs is designed to run in its own goroutine.
 func (p podTracker) streamContainerLogs(ctx context.Context, ctnTracker *containerTracker, maxLogSize uint) {
+	p.Logger.Tracef("begin streaming logs for container %s in %s", ctnTracker.Name, p.TrackedPod)
 	// create function for periodically capturing
 	// the logs from the container with backoff
 	logsFunc := func() (bool, error) {

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -19,7 +19,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -317,73 +316,49 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 func (c *client) WaitContainer(ctx context.Context, ctn *pipeline.Container) error {
 	c.Logger.Tracef("waiting for container %s", ctn.ID)
 
-	// create label selector for watching the pod
-	selector := fmt.Sprintf("pipeline=%s", fields.EscapeValue(c.Pod.ObjectMeta.Name))
-
-	// create options for watching the container
-	opts := metav1.ListOptions{
-		LabelSelector: selector,
-		Watch:         true,
+	tracker, ok := c.PodTracker.Containers[ctn.ID]
+	if !ok {
+		return fmt.Errorf("containerTracker is missing for %s", ctn.ID)
 	}
 
-	// send API call to capture channel for watching the container
+	// wait for the container terminated signal
+	<-tracker.Terminated
+
+	return nil
+}
+
+// inspectContainerStatuses signals when a container reaches a terminal state.
+func (p podTracker) inspectContainerStatuses(pod *v1.Pod) {
+	// check if the pod is in a pending state
 	//
-	// https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1?tab=doc#PodInterface
-	// ->
-	// https://pkg.go.dev/k8s.io/apimachinery/pkg/watch?tab=doc#Interface
-	// nolint: contextcheck // ignore non-inherited new context
-	podWatch, err := c.Kubernetes.CoreV1().Pods(c.config.Namespace).Watch(context.Background(), opts)
-	if err != nil {
-		return err
+	// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#PodStatus
+	if pod.Status.Phase == v1.PodPending {
+		// nothing to inspect if pod is in a pending state
+		return
 	}
 
-	defer podWatch.Stop()
-
-	for {
-		// capture new result from the channel
-		//
-		// https://pkg.go.dev/k8s.io/apimachinery/pkg/watch?tab=doc#Interface
-		result := <-podWatch.ResultChan()
-
-		// convert the object from the result to a pod
-		pod, ok := result.Object.(*v1.Pod)
+	// iterate through each container in the pod
+	for _, cst := range pod.Status.ContainerStatuses {
+		tracker, ok := p.Containers[cst.Name]
 		if !ok {
-			return fmt.Errorf("unable to watch pod %s", c.Pod.ObjectMeta.Name)
-		}
-
-		// check if the pod is in a pending state
-		//
-		// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#PodStatus
-		if pod.Status.Phase == v1.PodPending {
-			// skip pod if it's in a pending state
+			// unknown container
 			continue
 		}
 
-		// iterate through each container in the pod
-		for _, cst := range pod.Status.ContainerStatuses {
-			// check if the container has a matching ID
-			//
-			// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#ContainerStatus
-			if !strings.EqualFold(cst.Name, ctn.ID) {
-				// skip container if it's not a matching ID
-				continue
-			}
+		// check if the container is in a terminated state
+		//
+		// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#ContainerState
+		if cst.State.Terminated != nil {
+			// && len(cst.State.Terminated.Reason) > 0 {
+			// WaitContainer used to check Terminated.Reason as well.
+			// if that is still needed, then we can add that check here
+			// or retrieve the pod with something like this in WaitContainer:
+			// c.PodTracker.PodLister.Pods(c.config.Namespace).Get(c.Pod.GetName())
 
-			// check if the container is in a terminated state
-			//
-			// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#ContainerState
-			if cst.State.Terminated == nil {
-				// skip container if it's not in a terminated state
-				break
-			}
-
-			// check if the container has a terminated state reason
-			//
-			// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#ContainerStateTerminated
-			if len(cst.State.Terminated.Reason) > 0 {
-				// break watching the container as it's complete
-				return nil
-			}
+			tracker.terminatedOnce.Do(func() {
+				// let WaitContainer know the container is terminated
+				close(tracker.Terminated)
+			})
 		}
 	}
 }

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -281,6 +281,7 @@ func (p podTracker) streamContainerLogs(ctx context.Context, ctnTracker *contain
 			if maxLogSize > 0 && uint(len(ctnTracker.logs)) >= maxLogSize {
 				p.Logger.Trace("maximum log size reached")
 
+				ctnTracker.logs = append(ctnTracker.logs, []byte("LOGS TRUNCATED: Vela Runtime MaxLogSize exceeded.\n")...)
 				break
 			}
 		}

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -271,6 +271,8 @@ func (p podTracker) streamContainerLogs(ctx context.Context, ctnTracker *contain
 			return false, nil
 		}
 
+		defer stream.Close()
+
 		// create new reader from the container output
 		reader := bufio.NewReader(stream)
 

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -316,6 +316,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 func (c *client) WaitContainer(ctx context.Context, ctn *pipeline.Container) error {
 	c.Logger.Tracef("waiting for container %s", ctn.ID)
 
+	// get the containerTracker for this container
 	tracker, ok := c.PodTracker.Containers[ctn.ID]
 	if !ok {
 		return fmt.Errorf("containerTracker is missing for %s", ctn.ID)
@@ -339,6 +340,7 @@ func (p podTracker) inspectContainerStatuses(pod *v1.Pod) {
 
 	// iterate through each container in the pod
 	for _, cst := range pod.Status.ContainerStatuses {
+		// get the containerTracker for this container
 		tracker, ok := p.Containers[cst.Name]
 		if !ok {
 			// unknown container

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -417,6 +417,7 @@ func TestKubernetes_WaitContainer(t *testing.T) {
 				// this will trigger a sync which will use the fake clientset to get "updated"
 				pod := test.cached.DeepCopy()
 				pod.SetResourceVersion("older")
+
 				err = _engine.PodTracker.podInformer.Informer().GetIndexer().Add(pod)
 				if err != nil {
 					t.Errorf("loading the podInformer cache failed: %v", err)

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -398,7 +398,7 @@ func TestKubernetes_WaitContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		// anonymous function to allow "defer close(stopCh)" on each iteration
+		// anonymous function to allow "defer done()" on each iteration
 		func() {
 			// set up the fake k8s clientset so that it returns the final/updated state
 			_engine, err := NewMock(test.updated)
@@ -406,11 +406,11 @@ func TestKubernetes_WaitContainer(t *testing.T) {
 				t.Errorf("unable to create runtime engine: %v", err)
 			}
 
-			stopCh := make(chan struct{})
-			defer close(stopCh)
+			ctx, done := context.WithCancel(context.Background())
+			defer done()
 
 			// enable the add/update/delete funcs for pod changes
-			_engine.PodTracker.Start(stopCh)
+			_engine.PodTracker.Start(ctx)
 
 			go func() {
 				// revert the cached pod to an "older" version

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -5,8 +5,6 @@
 package kubernetes
 
 import (
-	"time"
-
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -186,19 +184,10 @@ func NewMock(_pod *v1.Pod, opts ...ClientOpt) (*client, error) {
 	)
 
 	// set the PodTracker (normally populated in SetupBuild)
-	tracker, err := newPodTracker(c.Logger, c.Kubernetes, c.Pod, time.Second*0)
+	tracker, err := mockPodTracker(c.Logger, c.Kubernetes, c.Pod)
 	if err != nil {
 		return c, err
 	}
-
-	// pre-populate the podInformer cache
-	err = tracker.podInformer.Informer().GetIndexer().Add(c.Pod)
-	if err != nil {
-		return c, err
-	}
-
-	// mock tracker is always ready
-	tracker.PodSynced = func() bool { return true }
 
 	c.PodTracker = tracker
 

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -30,6 +30,8 @@ type config struct {
 	Volumes []string
 	// PipelinePodsTemplateName has the name of the PipelinePodTemplate to retrieve from the Namespace
 	PipelinePodsTemplateName string
+	// maxLogSize is the max log size enforced by the executor
+	maxLogSize uint
 }
 
 type client struct {

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -186,7 +186,7 @@ func NewMock(_pod *v1.Pod, opts ...ClientOpt) (*client, error) {
 	)
 
 	// set the PodTracker (normally populated in SetupBuild)
-	tracker, err := NewPodTracker(c.Logger, c.Kubernetes, c.Pod, time.Second*0)
+	tracker, err := newPodTracker(c.Logger, c.Kubernetes, c.Pod, time.Second*0)
 	if err != nil {
 		return c, err
 	}

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -11,9 +11,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes/fake"
-	testcore "k8s.io/client-go/testing"
 )
 
 func TestKubernetes_New(t *testing.T) {
@@ -317,39 +314,3 @@ var (
 		},
 	}
 )
-
-// newMockWithWatch returns an Engine implementation that
-// integrates with a Kubernetes runtime and a FakeWatcher
-// that can be used to inject resource events into it.
-func newMockWithWatch(pod *v1.Pod, watchResource string, opts ...ClientOpt) (*client, *watch.RaceFreeFakeWatcher, error) {
-	// setup types
-	_engine, err := NewMock(pod, opts...)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// create a new fake kubernetes client
-	//
-	// https://pkg.go.dev/k8s.io/client-go/kubernetes/fake?tab=doc#NewSimpleClientset
-	_kubernetes := fake.NewSimpleClientset(pod)
-
-	// create a new fake watcher
-	//
-	// https://pkg.go.dev/k8s.io/apimachinery/pkg/watch?tab=doc#NewRaceFreeFake
-	_watch := watch.NewRaceFreeFake()
-
-	// create a new watch reactor with the fake watcher
-	//
-	// https://pkg.go.dev/k8s.io/client-go/testing?tab=doc#DefaultWatchReactor
-	reactor := testcore.DefaultWatchReactor(_watch, nil)
-
-	// add watch reactor to beginning of the client chain
-	//
-	// https://pkg.go.dev/k8s.io/client-go/testing?tab=doc#Fake.PrependWatchReactor
-	_kubernetes.PrependWatchReactor(watchResource, reactor)
-
-	// overwrite the mock kubernetes client
-	_engine.Kubernetes = _kubernetes
-
-	return _engine, _watch, nil
-}

--- a/runtime/kubernetes/opts.go
+++ b/runtime/kubernetes/opts.go
@@ -123,3 +123,15 @@ func WithPrivilegedImages(images []string) ClientOpt {
 		return nil
 	}
 }
+
+// WithMaxLogSize sets the maximum log size (in bytes) enforced in the executor.
+func WithMaxLogSize(size uint) ClientOpt {
+	return func(c *client) error {
+		c.Logger.Trace("configuring maximum log size in kubernetes runtime client")
+
+		// set the maximum container log size in the kubernetes client
+		c.config.maxLogSize = size
+
+		return nil
+	}
+}

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -200,3 +200,22 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 
 	return &tracker, nil
 }
+
+// mockPodTracker returns a new podTracker with the given pod pre-loaded in the cache.
+func mockPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Pod) (*podTracker, error) {
+	tracker, err := newPodTracker(log, clientset, pod, time.Second*0)
+	if err != nil {
+		return nil, err
+	}
+
+	// pre-populate the podInformer cache
+	err = tracker.podInformer.Informer().GetIndexer().Add(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	// mock tracker is always ready
+	tracker.PodSynced = func() bool { return true }
+
+	return tracker, err
+}

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -5,6 +5,7 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -133,11 +134,11 @@ func (p podTracker) getTrackedPod(obj interface{}) *v1.Pod {
 
 // Start kicks off the API calls to start populating the cache.
 // There is no need to run this in a separate goroutine (ie go podTracker.Start(stopCh)).
-func (p podTracker) Start(stopCh <-chan struct{}) {
+func (p podTracker) Start(ctx context.Context) {
 	p.Logger.Tracef("starting PodTracker for pod %s", p.TrackedPod)
 
 	// Start method is non-blocking and runs all registered informers in a dedicated goroutine.
-	p.informerFactory.Start(stopCh)
+	p.informerFactory.Start(ctx.Done())
 }
 
 // newPodTracker initializes a podTracker with a given clientset for a given pod.

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -167,6 +167,7 @@ func NewPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 		}
 	}
 
+	// initialize podTracker
 	tracker := podTracker{
 		Logger:          log,
 		TrackedPod:      trackedPod,
@@ -177,7 +178,8 @@ func NewPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 		Containers:      containers,
 	}
 
-	tracker.podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	// register event handler funcs in podInformer
+	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    tracker.HandlePodAdd,
 		UpdateFunc: tracker.HandlePodUpdate,
 		DeleteFunc: tracker.HandlePodDelete,

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -28,9 +28,9 @@ import (
 	"github.com/go-vela/worker/internal/log"
 )
 
-// TruncatedLogs is an error that allows the log streaming to indicate
+// ErrTruncatedLogs is an error that allows the log streaming to indicate
 // that it had to stop streaming logs due to maxLogSize.
-var TruncatedLogs = errors.New("TruncatedLogs")
+var ErrTruncatedLogs = errors.New("TruncatedLogs")
 
 // containerTracker contains useful signals that are managed by the podTracker.
 type containerTracker struct {
@@ -46,7 +46,7 @@ type containerTracker struct {
 	LogsError error
 }
 
-// Logs provides an io.Reader that streams all the logs streamed so far
+// Logs provides an io.Reader that streams all the logs streamed so far.
 func (c *containerTracker) Logs() io.Reader {
 	return c.logs.NewReader()
 }

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -220,19 +220,19 @@ func mockPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.P
 		pod.ObjectMeta.Namespace = "test"
 	}
 
-	tracker, err := newPodTracker(log, clientset, pod, time.Second*0)
+	tracker, err := newPodTracker(log, clientset, pod, 0*time.Second)
 	if err != nil {
 		return nil, err
 	}
+
+	// init containerTrackers as well
+	tracker.TrackContainers(pod.Spec.Containers)
 
 	// pre-populate the podInformer cache
 	err = tracker.podInformer.Informer().GetIndexer().Add(pod)
 	if err != nil {
 		return nil, err
 	}
-
-	// mock tracker is always ready
-	tracker.PodSynced = func() bool { return true }
 
 	return tracker, err
 }

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -64,6 +64,7 @@ func (p podTracker) HandlePodAdd(newObj interface{}) {
 		// not valid or not our tracked pod
 		return
 	}
+
 	p.inspectContainerStatuses(newPod)
 }
 
@@ -95,6 +96,7 @@ func (p podTracker) HandlePodDelete(oldObj interface{}) {
 		// not valid or not our tracked pod
 		return
 	}
+
 	p.inspectContainerStatuses(oldPod)
 }
 
@@ -130,7 +132,7 @@ func (p podTracker) getTrackedPod(obj interface{}) *v1.Pod {
 }
 
 // Start kicks off the API calls to start populating the cache.
-// There is no need to run this in a separate goroutine. (ie go podTracker.Start(stopCh))
+// There is no need to run this in a separate goroutine (ie go podTracker.Start(stopCh)).
 func (p podTracker) Start(stopCh <-chan struct{}) {
 	p.Logger.Tracef("starting PodTracker for pod %s", p.TrackedPod)
 
@@ -143,6 +145,7 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 	if pod == nil {
 		return nil, fmt.Errorf("newPodTracker expected a pod, got nil")
 	}
+
 	trackedPod := pod.ObjectMeta.Namespace + "/" + pod.ObjectMeta.Name
 	log.Tracef("creating PodTracker for pod %s", trackedPod)
 
@@ -193,5 +196,6 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 		UpdateFunc: tracker.HandlePodUpdate,
 		DeleteFunc: tracker.HandlePodDelete,
 	})
+
 	return &tracker, nil
 }

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -134,7 +134,7 @@ func (p podTracker) getTrackedPod(obj interface{}) *v1.Pod {
 
 // Start kicks off the API calls to start populating the cache.
 // There is no need to run this in a separate goroutine (ie go podTracker.Start(stopCh)).
-func (p podTracker) Start(ctx context.Context) {
+func (p podTracker) Start(ctx context.Context, maxLogSize uint) {
 	p.Logger.Tracef("starting PodTracker for pod %s", p.TrackedPod)
 
 	// Start method is non-blocking and runs all registered informers in a dedicated goroutine.

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -142,16 +142,17 @@ func (p podTracker) Start(ctx context.Context) {
 }
 
 // TrackContainers creates a containerTracker for each container.
-func (p podTracker) TrackContainers(containers []v1.Container) {
-	ctnTrackers := map[string]*containerTracker{}
+func (p *podTracker) TrackContainers(containers []v1.Container) {
+	if p.Containers == nil {
+		p.Containers = map[string]*containerTracker{}
+	}
+
 	for _, ctn := range containers {
-		ctnTrackers[ctn.Name] = &containerTracker{
+		p.Containers[ctn.Name] = &containerTracker{
 			Name:       ctn.Name,
 			Terminated: make(chan struct{}),
 		}
 	}
-
-	p.Containers = ctnTrackers
 }
 
 // newPodTracker initializes a podTracker with a given clientset for a given pod.

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -34,8 +34,8 @@ type containerTracker struct {
 	// TODO: collect streaming logs here before TailContainer is called
 }
 
-// podTracker contains Informers used to watch and synchronize local k8s caches
-// This is similar to a typical Kubernetes controller (eg like k8s.io/sample-controller.Controller)
+// podTracker contains Informers used to watch and synchronize local k8s caches.
+// This is similar to a typical Kubernetes controller (eg like k8s.io/sample-controller.Controller).
 type podTracker struct {
 	// https://pkg.go.dev/github.com/sirupsen/logrus#Entry
 	Logger *logrus.Entry
@@ -57,7 +57,7 @@ type podTracker struct {
 	Containers map[string]containerTracker
 }
 
-// HandlePodAdd is an AddFunc for cache.ResourceEventHandlerFuncs for Pods
+// HandlePodAdd is an AddFunc for cache.ResourceEventHandlerFuncs for Pods.
 func (p podTracker) HandlePodAdd(newObj interface{}) {
 	newPod := p.getTrackedPod(newObj)
 	if newPod == nil {
@@ -65,13 +65,13 @@ func (p podTracker) HandlePodAdd(newObj interface{}) {
 		return
 	}
 	p.inspectContainerStatuses(newPod)
-	return
 }
 
-// HandlePodUpdate is an UpdateFunc for cache.ResourceEventHandlerFuncs for Pods
+// HandlePodUpdate is an UpdateFunc for cache.ResourceEventHandlerFuncs for Pods.
 func (p podTracker) HandlePodUpdate(oldObj, newObj interface{}) {
 	oldPod := p.getTrackedPod(oldObj)
 	newPod := p.getTrackedPod(newObj)
+
 	if oldPod == nil || newPod == nil {
 		// not valid or not our tracked pod
 		return
@@ -84,11 +84,11 @@ func (p podTracker) HandlePodUpdate(oldObj, newObj interface{}) {
 	//		return
 	//	}
 	//}
+
 	p.inspectContainerStatuses(newPod)
-	return
 }
 
-// HandlePodDelete is an DeleteFunc for cache.ResourceEventHandlerFuncs for Pods
+// HandlePodDelete is an DeleteFunc for cache.ResourceEventHandlerFuncs for Pods.
 func (p podTracker) HandlePodDelete(oldObj interface{}) {
 	oldPod := p.getTrackedPod(oldObj)
 	if oldPod == nil {
@@ -96,31 +96,36 @@ func (p podTracker) HandlePodDelete(oldObj interface{}) {
 		return
 	}
 	p.inspectContainerStatuses(oldPod)
-	return
 }
 
 // getTrackedPod tries to convert the obj into a Pod and makes sure it is the tracked Pod.
 // This should only be used by the funcs of cache.ResourceEventHandlerFuncs.
 func (p podTracker) getTrackedPod(obj interface{}) *v1.Pod {
-	var pod *v1.Pod
-	var ok bool
+	var (
+		pod *v1.Pod
+		ok  bool
+	)
+
 	if pod, ok = obj.(*v1.Pod); !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			p.Logger.Errorf("error decoding pod, invalid type")
 			return nil
 		}
+
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
 			p.Logger.Errorf("error decoding pod tombstone, invalid type")
 			return nil
 		}
 	}
+
 	trackedPod := pod.GetNamespace() + "/" + pod.GetName()
 	if trackedPod != p.TrackedPod {
 		p.Logger.Errorf("error got unexpected pod: %s", trackedPod)
 		return nil
 	}
+
 	return pod
 }
 
@@ -133,10 +138,10 @@ func (p podTracker) Start(stopCh <-chan struct{}) {
 	p.informerFactory.Start(stopCh)
 }
 
-// NewPodTracker initializes a podTracker with a given clientset for a given pod.
-func NewPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Pod, defaultResync time.Duration) (*podTracker, error) {
+// newPodTracker initializes a podTracker with a given clientset for a given pod.
+func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Pod, defaultResync time.Duration) (*podTracker, error) {
 	if pod == nil {
-		return nil, fmt.Errorf("NewPodTracker expected a pod, got nil")
+		return nil, fmt.Errorf("newPodTracker expected a pod, got nil")
 	}
 	trackedPod := pod.ObjectMeta.Namespace + "/" + pod.ObjectMeta.Name
 	log.Tracef("creating PodTracker for pod %s", trackedPod)

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -40,6 +40,10 @@ type containerTracker struct {
 type podTracker struct {
 	// https://pkg.go.dev/github.com/sirupsen/logrus#Entry
 	Logger *logrus.Entry
+	// Namespace is the namespace the tracked pod is in
+	Namespace string
+	// Name is the name of the pod
+	Name string
 	// TrackedPod is the Namespace/Name of the tracked pod
 	TrackedPod string
 
@@ -194,6 +198,8 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 	// initialize podTracker
 	tracker := podTracker{
 		Logger:          log,
+		Namespace:       pod.ObjectMeta.Namespace,
+		Name:            pod.ObjectMeta.Name,
 		TrackedPod:      trackedPod,
 		Kubernetes:      clientset,
 		informerFactory: informerFactory,

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package kubernetes
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	kubeinformers "k8s.io/client-go/informers"
+	informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// podTracker contains Informers used to watch and synchronize local k8s caches
+// This is similar to a typical Kubernetes controller (eg like k8s.io/sample-controller.Controller)
+type podTracker struct {
+	// https://pkg.go.dev/github.com/sirupsen/logrus#Entry
+	Logger *logrus.Entry
+	// TrackedPod is the Namespace/Name of the tracked pod
+	TrackedPod string
+
+	// informerFactory is used to create Informers and Listers
+	informerFactory kubeinformers.SharedInformerFactory
+	// podInformer watches the given pod, caches the results, and makes them available in podLister
+	podInformer informers.PodInformer
+
+	// PodLister helps list Pods. All objects returned here must be treated as read-only.
+	PodLister listers.PodLister
+	// PodSynced is a function that can be used to determine if an informer has synced.
+	// This is useful for determining if caches have synced.
+	PodSynced cache.InformerSynced
+}
+
+// AddPodInformerEventHandler adds an event handler to the cache.SharedInformer for the Pod.
+// Events to a single handler are delivered sequentially, but there is no coordination
+// between different handlers.
+// Make sure to add the ResourceEventHandler with this before running Start.
+func (p podTracker) AddPodInformerEventHandler(handler cache.ResourceEventHandler) {
+	p.podInformer.Informer().AddEventHandler(handler)
+}
+
+// Start kicks off the API calls to start populating the cache.
+// There is no need to run this in a separate goroutine. (ie go podTracker.Start(stopCh))
+func (p podTracker) Start(stopCh <-chan struct{}) {
+	p.Logger.Tracef("starting PodTracker for pod %s", p.TrackedPod)
+
+	// Start method is non-blocking and runs all registered informers in a dedicated goroutine.
+	p.informerFactory.Start(stopCh)
+}
+
+func NewPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Pod, defaultResync time.Duration) (*podTracker, error) {
+	trackedPod := pod.ObjectMeta.Namespace + "/" + pod.ObjectMeta.Name
+	log.Tracef("creating PodTracker for pod %s", trackedPod)
+
+	// create label selector for watching the pod
+	selector, err := labels.NewRequirement(
+		"pipeline",
+		selection.Equals,
+		[]string{fields.EscapeValue(pod.ObjectMeta.Name)},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// create filtered Informer factory which is commonly used for k8s controllers
+	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(
+		clientset,
+		defaultResync,
+		kubeinformers.WithNamespace(pod.ObjectMeta.Namespace),
+		kubeinformers.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
+			listOptions.LabelSelector = selector.String()
+		}),
+	)
+	podInformer := informerFactory.Core().V1().Pods()
+
+	tracker := podTracker{
+		Logger:          log,
+		TrackedPod:      trackedPod,
+		informerFactory: informerFactory,
+		podInformer:     podInformer,
+		PodLister:       podInformer.Lister(),
+		PodSynced:       podInformer.Informer().HasSynced,
+	}
+
+	return &tracker, nil
+}

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -48,6 +48,8 @@ type podTracker struct {
 	// podInformer watches the given pod, caches the results, and makes them available in podLister
 	podInformer informers.PodInformer
 
+	// https://pkg.go.dev/k8s.io/client-go/kubernetes#Interface
+	Kubernetes kubernetes.Interface
 	// PodLister helps list Pods. All objects returned here must be treated as read-only.
 	PodLister listers.PodLister
 	// PodSynced is a function that can be used to determine if an informer has synced.
@@ -193,6 +195,7 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 	tracker := podTracker{
 		Logger:          log,
 		TrackedPod:      trackedPod,
+		Kubernetes:      clientset,
 		informerFactory: informerFactory,
 		podInformer:     podInformer,
 		PodLister:       podInformer.Lister(),

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -5,6 +5,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -134,6 +135,9 @@ func (p podTracker) Start(stopCh <-chan struct{}) {
 
 // NewPodTracker initializes a podTracker with a given clientset for a given pod.
 func NewPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Pod, defaultResync time.Duration) (*podTracker, error) {
+	if pod == nil {
+		return nil, fmt.Errorf("NewPodTracker expected a pod, got nil")
+	}
 	trackedPod := pod.ObjectMeta.Namespace + "/" + pod.ObjectMeta.Name
 	log.Tracef("creating PodTracker for pod %s", trackedPod)
 

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -148,6 +148,10 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 	}
 
 	trackedPod := pod.ObjectMeta.Namespace + "/" + pod.ObjectMeta.Name
+	if pod.ObjectMeta.Name == "" || pod.ObjectMeta.Namespace == "" {
+		return nil, fmt.Errorf("newPodTracker expects pod to have Name and Namespace, got %s", trackedPod)
+	}
+
 	log.Tracef("creating PodTracker for pod %s", trackedPod)
 
 	// create label selector for watching the pod
@@ -203,6 +207,14 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 
 // mockPodTracker returns a new podTracker with the given pod pre-loaded in the cache.
 func mockPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Pod) (*podTracker, error) {
+	// Make sure test pods are valid before passing to PodTracker (ie support &v1.Pod{}).
+	if pod.ObjectMeta.Name == "" {
+		pod.ObjectMeta.Name = "test-pod"
+	}
+	if pod.ObjectMeta.Namespace == "" {
+		pod.ObjectMeta.Namespace = "test"
+	}
+
 	tracker, err := newPodTracker(log, clientset, pod, time.Second*0)
 	if err != nil {
 		return nil, err

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -165,6 +165,7 @@ func (p podTracker) Start(ctx context.Context, maxLogSize uint) {
 
 // TrackContainers creates a containerTracker for each container.
 func (p *podTracker) TrackContainers(containers []v1.Container) {
+	p.Logger.Tracef("adding %d containerTrackers for pod %s", len(containers), p.TrackedPod)
 	if p.Containers == nil {
 		p.Containers = map[string]*containerTracker{}
 	}

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -7,6 +7,7 @@ package kubernetes
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -24,6 +25,10 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
+
+// TruncatedLogs is an error that allows the log streaming to indicate
+// that it had to stop streaming logs due to maxLogSize.
+var TruncatedLogs = errors.New("TruncatedLogs")
 
 // containerTracker contains useful signals that are managed by the podTracker.
 type containerTracker struct {

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -54,7 +54,7 @@ type podTracker struct {
 	PodSynced cache.InformerSynced
 
 	// Containers maps the container name to a containerTracker
-	Containers map[string]containerTracker
+	Containers map[string]*containerTracker
 }
 
 // HandlePodAdd is an AddFunc for cache.ResourceEventHandlerFuncs for Pods.
@@ -168,9 +168,9 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 	podInformer := informerFactory.Core().V1().Pods()
 
 	// initialize the containerTrackers
-	containers := map[string]containerTracker{}
+	containers := map[string]*containerTracker{}
 	for _, ctn := range pod.Spec.Containers {
-		containers[ctn.Name] = containerTracker{
+		containers[ctn.Name] = &containerTracker{
 			Name:       ctn.Name,
 			Terminated: make(chan struct{}),
 		}

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -142,7 +142,7 @@ func (p podTracker) Start(ctx context.Context) {
 }
 
 // TrackContainers creates a containerTracker for each container.
-func (p podTracker) TrackContainers(containers v1.Container) {
+func (p podTracker) TrackContainers(containers []v1.Container) {
 	ctnTrackers := map[string]*containerTracker{}
 	for _, ctn := range containers {
 		ctnTrackers[ctn.Name] = &containerTracker{
@@ -214,6 +214,7 @@ func mockPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.P
 	if pod.ObjectMeta.Name == "" {
 		pod.ObjectMeta.Name = "test-pod"
 	}
+
 	if pod.ObjectMeta.Namespace == "" {
 		pod.ObjectMeta.Namespace = "test"
 	}

--- a/runtime/kubernetes/pod_tracker_test.go
+++ b/runtime/kubernetes/pod_tracker_test.go
@@ -54,9 +54,9 @@ func TestNewPodTracker(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewPodTracker(logger, clientset, tt.pod, time.Second*0)
+			_, err := newPodTracker(logger, clientset, tt.pod, time.Second*0)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("NewPodTracker() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("newPodTracker() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
@@ -131,7 +131,7 @@ func Test_podTracker_getTrackedPod(t *testing.T) {
 				Logger:     logger,
 				TrackedPod: tt.trackedPod,
 				// other fields not used by getTrackedPod
-				// if they're needed, use NewPodTracker
+				// if they're needed, use newPodTracker
 			}
 			if got := p.getTrackedPod(tt.obj); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getTrackedPod() = %v, want %v", got, tt.want)

--- a/runtime/kubernetes/pod_tracker_test.go
+++ b/runtime/kubernetes/pod_tracker_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestNewPodTracker(t *testing.T) {
+	// setup types
+	logger := logrus.NewEntry(logrus.StandardLogger())
+	clientset := fake.NewSimpleClientset()
+
+	tests := []struct {
+		name    string
+		pod     *v1.Pod
+		wantErr bool
+	}{
+		{
+			name:    "pass-with-pod",
+			pod:     _pod,
+			wantErr: false,
+		},
+		{
+			name:    "error-with-nil-pod",
+			pod:     nil,
+			wantErr: true,
+		},
+		{
+			name: "fail-with-pod",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "github-octocat-1-for-some-odd-reason-this-name-is-way-too-long-and-will-cause-an-error",
+					Namespace: _pod.ObjectMeta.Namespace,
+					Labels:    _pod.ObjectMeta.Labels,
+				},
+				TypeMeta: _pod.TypeMeta,
+				Spec:     _pod.Spec,
+				Status:   _pod.Status,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPodTracker(logger, clientset, tt.pod, time.Second*0)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewPodTracker() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func Test_podTracker_getTrackedPod(t *testing.T) {
+	// setup types
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	tests := []struct {
+		name       string
+		trackedPod string // namespace/podName
+		obj        interface{}
+		want       *v1.Pod
+	}{
+		{
+			name:       "got-tracked-pod",
+			trackedPod: "test/github-octocat-1",
+			obj:        _pod,
+			want:       _pod,
+		},
+		{
+			name:       "wrong-pod",
+			trackedPod: "test/github-octocat-2",
+			obj:        _pod,
+			want:       nil,
+		},
+		{
+			name:       "invalid-type",
+			trackedPod: "test/github-octocat-1",
+			obj:        new(v1.PodTemplate),
+			want:       nil,
+		},
+		{
+			name:       "nil",
+			trackedPod: "test/nil",
+			obj:        nil,
+			want:       nil,
+		},
+		{
+			name:       "tombstone-pod",
+			trackedPod: "test/github-octocat-1",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "test/github-octocat-1",
+				Obj: _pod,
+			},
+			want: _pod,
+		},
+		{
+			name:       "tombstone-nil",
+			trackedPod: "test/github-octocat-1",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "test/github-octocat-1",
+				Obj: nil,
+			},
+			want: nil,
+		},
+		{
+			name:       "tombstone-invalid-type",
+			trackedPod: "test/github-octocat-1",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "test/github-octocat-1",
+				Obj: new(v1.PodTemplate),
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := podTracker{
+				Logger:     logger,
+				TrackedPod: tt.trackedPod,
+				// other fields not used by getTrackedPod
+				// if they're needed, use NewPodTracker
+			}
+			if got := p.getTrackedPod(tt.obj); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getTrackedPod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime/kubernetes/pod_tracker_test.go
+++ b/runtime/kubernetes/pod_tracker_test.go
@@ -54,7 +54,7 @@ func TestNewPodTracker(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := newPodTracker(logger, clientset, tt.pod, time.Second*0)
+			_, err := newPodTracker(logger, clientset, tt.pod, 0*time.Second)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newPodTracker() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/runtime/setup.go
+++ b/runtime/setup.go
@@ -38,6 +38,8 @@ type Setup struct {
 	PodsTemplateFile string
 	// specifies a list of privileged images to use for the runtime client
 	PrivilegedImages []string
+	// specifies the maximum log size (expose an executor setting for kubernetes runtime)
+	MaxLogSize uint
 }
 
 // Docker creates and returns a Vela engine capable of
@@ -70,6 +72,7 @@ func (s *Setup) Kubernetes() (Engine, error) {
 		kubernetes.WithPodsTemplate(s.PodsTemplateName, s.PodsTemplateFile),
 		kubernetes.WithPrivilegedImages(s.PrivilegedImages),
 		kubernetes.WithLogger(s.Logger),
+		kubernetes.WithMaxLogSize(s.MaxLogSize),
 	)
 }
 


### PR DESCRIPTION
Part of https://github.com/go-vela/community/issues/519
Builds on https://github.com/go-vela/worker/pull/302 which should be merged first.

This is a bug fix and an enhancement. The goal is to improve log streaming with the kubernetes runtime
to prevent missing logs, logs that can be observed when tailing with something like [`stern`](https://github.com/stern/stern).

Only these commits are part of this PR (everything after #302)
- enhance(k8s): expose executor.max_log_size to kubernetes runtime
- enhance(k8s): add k8s clientset to podTracker
- enhance(k8s): add k8s namespace to containerTracker
- refactor(k8s): start streaming logs before steps start
- enhance: add LOGS TRUNCATED at end of logs if truncated

TODO:
- [ ] Merge #302
- [ ] Rebase on main
- [ ] Expand PR Description
- [ ] Make it even more robust
- [ ] Probably add more tests
- [ ] etc

Alternative fixes that didn't work out:
Closes #277
Closes #286