### PR TITLE
refactor(executor): clarify why use different contexts

### DIFF
--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -18,14 +18,14 @@ import (
 // exec is a helper function to poll the queue
 // and execute Vela pipelines for the Worker.
 // nolint: nilerr // ignore returning nil - don't want to crash worker
-func (w *Worker) exec(ctx context.Context, index int) error {
+func (w *Worker) exec(index int) error {
 	var err error
 
 	// setup the version
 	v := version.New()
 
 	// capture an item from the queue
-	item, err := w.Queue.Pop(ctx)
+	item, err := w.Queue.Pop(context.Background())
 	if err != nil {
 		return err
 	}
@@ -93,8 +93,9 @@ func (w *Worker) exec(ctx context.Context, index int) error {
 		t = time.Duration(item.Repo.GetTimeout()) * time.Minute
 	}
 
-	// create a build context
-	buildCtx, done := context.WithCancel(ctx)
+	// create a build context (from a background context
+	// so that other builds can't inadvertently cancel this build)
+	buildCtx, done := context.WithCancel(context.Background())
 	defer done()
 
 	// add to the background context with a timeout

--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -104,9 +104,10 @@ func (w *Worker) exec(ctx context.Context, index int) error {
 
 	defer func() {
 		logger.Info("destroying build")
-		// destroy the build with the executor
-		// using buildCtx instead of timeoutCtx so that it happens after the timeout
-		err = _executor.DestroyBuild(buildCtx)
+
+		// destroy the build with the executor (pass a background
+		// context to guarantee all build resources are destroyed).
+		err = _executor.DestroyBuild(context.Background())
 		if err != nil {
 			logger.Errorf("unable to destroy build: %v", err)
 		}

--- a/cmd/vela-worker/operate.go
+++ b/cmd/vela-worker/operate.go
@@ -105,7 +105,10 @@ func (w *Worker) operate(ctx context.Context) error {
 					return nil
 				default:
 					// exec operator subprocess to poll and execute builds
-					err = w.exec(gctx, id)
+					// (do not pass the context to avoid errors in one
+					// executor+build inadvertently canceling other builds)
+					// nolint: contextcheck // ignore passing context
+					err = w.exec(id)
 					if err != nil {
 						// log the error received from the executor
 						//

--- a/cmd/vela-worker/operate.go
+++ b/cmd/vela-worker/operate.go
@@ -105,8 +105,7 @@ func (w *Worker) operate(ctx context.Context) error {
 					return nil
 				default:
 					// exec operator subprocess to poll and execute builds
-					// nolint: contextcheck // ignore passing context
-					err = w.exec(id)
+					err = w.exec(gctx, id)
 					if err != nil {
 						// log the error received from the executor
 						//


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/562

~Pass the context along in the executor. The `buildCtx` is derived from the global ctx (`gctx`) so that signal-based worker shutdown trickles down to the `buildCtx` as well (see [cmd/vela-worker/start.go](https://github.com/go-vela/worker/blob/master/cmd/vela-worker/start.go#L27-L53)).~

I documented why we do not pass the executor context and derive the `buildCtx` from it.

Since there are several contexts in the `exec()` function, I renamed `ctx` to `timeoutCtx` to clarify which context is getting passed to each method.