### PR TITLE
revert(k8s): Revert go-vela/pkg-runtime#151

### DIFF
--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -241,15 +241,8 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 		//
 		// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#PodLogOptions
 		opts := &v1.PodLogOptions{
-			Container: ctn.ID,
-			Follow:    true,
-			// steps can exit quickly, and might be gone before
-			// log tailing has started, so we need to request
-			// logs for previously exited containers as well.
-			// Pods get deleted after job completion, and names for
-			// pod+container don't get reused. So, previous
-			// should only retrieve logs for the current build step.
-			Previous:   true,
+			Container:  ctn.ID,
+			Follow:     true,
 			Timestamps: false,
 		}
 


### PR DESCRIPTION
go-vela/pkg-runtime#151 was ineffective (did not improve things) and caused a lot of errors in the logs:

```
{"build":...,"executor":"linux","host":"...",
"level":"error",
"msg":"previous terminated container \"...\" in pod \"...\" not found",
"repo":"...","runtime":"kubernetes","time":"2022-04-14T18:58:36Z","user":"...","version":"..."}
```

Another user also reported this issue in slack, and I confirmed.
https://gophers.slack.com/archives/CNRRKE8KY/p1646859613212159?thread_ts=1646859573.285529&cid=CNRRKE8KY