### PR TITLE
bugfix(k8s): add newline to init step output

### DIFF
--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -23,7 +23,7 @@ import (
 func (c *client) InspectBuild(ctx context.Context, b *pipeline.Build) ([]byte, error) {
 	c.Logger.Tracef("inspecting build pod for pipeline %s", b.ID)
 
-	output := []byte(fmt.Sprintf("> Inspecting pod for pipeline %s", b.ID))
+	output := []byte(fmt.Sprintf("> Inspecting pod for pipeline %s\n", b.ID))
 
 	// TODO: The environment gets populated in AssembleBuild, after InspectBuild runs.
 	//       But, we should make sure that secrets can't be leaked here anyway.


### PR DESCRIPTION
A `\n` was missing from the init logs, causing this:
```
> Inspecting pod for pipeline org-repo-32metadata:
  creationTimestamp: null
  name: org-repo-32
spec:
...
```

So, this adds the missing newline.