### PR TITLE
bugfix(k8s): avoid "index out of range" panic by replacing magic indexes with containerLookup map

### DIFF
--- a/runtime/kubernetes/build_test.go
+++ b/runtime/kubernetes/build_test.go
@@ -392,6 +392,7 @@ func TestKubernetes_AssembleBuild(t *testing.T) {
 	for _, test := range tests {
 		_engine, err := NewMock(test.k8sPod)
 		_engine.Pod = test.enginePod
+
 		_engine.containersLookup = map[string]int{}
 		for i, ctn := range test.enginePod.Spec.Containers {
 			_engine.containersLookup[ctn.Name] = i

--- a/runtime/kubernetes/build_test.go
+++ b/runtime/kubernetes/build_test.go
@@ -392,6 +392,10 @@ func TestKubernetes_AssembleBuild(t *testing.T) {
 	for _, test := range tests {
 		_engine, err := NewMock(test.k8sPod)
 		_engine.Pod = test.enginePod
+		_engine.containersLookup = map[string]int{}
+		for i, ctn := range test.enginePod.Spec.Containers {
+			_engine.containersLookup[ctn.Name] = i
+		}
 
 		if err != nil {
 			t.Errorf("unable to create runtime engine: %v", err)

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -81,8 +81,7 @@ func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *p
 	}
 
 	// set the pod container image to the parsed step image
-	// (-1 to convert to 0-based index, -1 for init which isn't a container)
-	c.Pod.Spec.Containers[ctn.Number-2].Image = _image
+	c.Pod.Spec.Containers[c.containersLookup[ctn.ID]].Image = _image
 
 	// send API call to patch the pod with the new container image
 	//
@@ -195,6 +194,9 @@ func (c *client) SetupContainer(ctx context.Context, ctn *pipeline.Container) er
 		container.Args = append(container.Args, ctn.Commands...)
 	}
 
+	// record the index for this container
+	c.containersLookup[ctn.ID] = len(c.Pod.Spec.Containers)
+
 	// add the container definition to the pod spec
 	//
 	// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#PodSpec
@@ -209,8 +211,7 @@ func (c *client) setupContainerEnvironment(ctn *pipeline.Container) error {
 	c.Logger.Tracef("setting up environment for container %s", ctn.ID)
 
 	// get the matching container spec
-	// (-1 to convert to 0-based index, -1 for injected init container)
-	container := &c.Pod.Spec.Containers[ctn.Number-2]
+	container := &c.Pod.Spec.Containers[c.containersLookup[ctn.ID]]
 	if !strings.EqualFold(container.Name, ctn.ID) {
 		return fmt.Errorf("wrong container! got %s instead of %s", container.Name, ctn.ID)
 	}

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -236,6 +236,11 @@ func TestKubernetes_SetupContainer(t *testing.T) {
 		i := len(_engine.Pod.Spec.Containers) - 1
 		ctn := _engine.Pod.Spec.Containers[i]
 
+		// make sure the lookup map is working as expected
+		if j := _engine.containersLookup[ctn.Name]; i != j {
+			t.Errorf("expected containersLookup[ctn.Name] to be %d, got %d", i, j)
+		}
+
 		// Make sure Container has Privileged configured correctly
 		if test.wantPrivileged {
 			if ctn.SecurityContext == nil {

--- a/runtime/kubernetes/image.go
+++ b/runtime/kubernetes/image.go
@@ -53,8 +53,9 @@ func (c *client) InspectImage(ctx context.Context, ctn *pipeline.Container) ([]b
 	}
 
 	// marshal the image information from the container
-	// (-1 to convert to 0-based index, -1 for init which isn't a container)
-	image, err := json.MarshalIndent(c.Pod.Spec.Containers[ctn.Number-2].Image, "", " ")
+	image, err := json.MarshalIndent(
+		c.Pod.Spec.Containers[c.containersLookup[ctn.ID]].Image, "", " ",
+	)
 	if err != nil {
 		return output, err
 	}

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -42,6 +42,8 @@ type client struct {
 	Logger *logrus.Entry
 	// https://pkg.go.dev/k8s.io/api/core/v1#Pod
 	Pod *v1.Pod
+	// containersLookup maps the container name to its index in Containers
+	containersLookup map[string]int
 	// PipelinePodTemplate has default values to be used in Setup* methods
 	PipelinePodTemplate *velav1alpha1.PipelinePodTemplate
 	// commonVolumeMounts includes workspace mount and any global host mounts (VELA_RUNTIME_VOLUMES)
@@ -61,6 +63,7 @@ func New(opts ...ClientOpt) (*client, error) {
 	// create new fields
 	c.config = new(config)
 	c.Pod = new(v1.Pod)
+	c.containersLookup = map[string]int{}
 
 	// create new logger for the client
 	//
@@ -140,6 +143,11 @@ func NewMock(_pod *v1.Pod, opts ...ClientOpt) (*client, error) {
 	// create new fields
 	c.config = new(config)
 	c.Pod = new(v1.Pod)
+
+	c.containersLookup = map[string]int{}
+	for i, ctn := range _pod.Spec.Containers {
+		c.containersLookup[ctn.Name] = i
+	}
 
 	// create new logger for the client
 	//


### PR DESCRIPTION
A bug report in slack pointed out that with services the kubernetes Runtime sometimes gets the wrong container.
See: https://gophers.slack.com/archives/CNRRKE8KY/p1646859800708539?thread_ts=1646859573.285529&cid=CNRRKE8KY

> I am also seeing a crash when adding services to the pipeline, panic: runtime error: index out of range [-1].  It looks like the logic https://github.com/go-vela/worker/blob/7c9599fdd5b4cb9d26ff235d41479cfe56f4f3ba/runtime/kubernetes/image.go#L55-L57 to exclude the init isn’t holding true on my deployment when using services.

So, this replaces magic index calculation with an index lookup map.