### PR TITLE
tests: Convert runtime tests to subtests

### DIFF
--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -50,11 +50,13 @@ func TestRuntime_FromContext(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := FromContext(test.context)
+		t.Run(test.name, func(t *testing.T) {
+			got := FromContext(test.context)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("FromContext is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("FromContext is %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 
@@ -96,15 +98,17 @@ func TestRuntime_FromGinContext(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		if test.value != nil {
-			test.context.Set(key, test.value)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			if test.value != nil {
+				test.context.Set(key, test.value)
+			}
 
-		got := FromGinContext(test.context)
+			got := FromGinContext(test.context)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("FromGinContext is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("FromGinContext is %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -25,19 +25,23 @@ func TestRuntime_FromContext(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		context context.Context
 		want    Engine
 	}{
 		{
+			name: "valid runtime in context",
 			// nolint: staticcheck // ignore using string with context value
 			context: context.WithValue(context.Background(), key, _engine),
 			want:    _engine,
 		},
 		{
+			name:    "runtime not in context",
 			context: context.Background(),
 			want:    nil,
 		},
 		{
+			name: "invalid runtime in context",
 			// nolint: staticcheck // ignore using string with context value
 			context: context.WithValue(context.Background(), key, "foo"),
 			want:    nil,
@@ -65,21 +69,25 @@ func TestRuntime_FromGinContext(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		context *gin.Context
 		value   interface{}
 		want    Engine
 	}{
 		{
+			name:    "valid runtime in context",
 			context: new(gin.Context),
 			value:   _engine,
 			want:    _engine,
 		},
 		{
+			name:    "runtime not in context",
 			context: new(gin.Context),
 			value:   nil,
 			want:    nil,
 		},
 		{
+			name:    "invalid runtime in context",
 			context: new(gin.Context),
 			value:   "foo",
 			want:    nil,

--- a/runtime/docker/build_test.go
+++ b/runtime/docker/build_test.go
@@ -20,10 +20,12 @@ func TestDocker_InspectBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
@@ -56,10 +58,12 @@ func TestDocker_SetupBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
@@ -86,10 +90,12 @@ func TestDocker_SetupBuild(t *testing.T) {
 func TestDocker_AssembleBuild(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
@@ -121,10 +127,12 @@ func TestDocker_AssembleBuild(t *testing.T) {
 func TestDocker_RemoveBuild(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},

--- a/runtime/docker/build_test.go
+++ b/runtime/docker/build_test.go
@@ -33,19 +33,21 @@ func TestDocker_InspectBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.InspectBuild(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			_, err = _engine.InspectBuild(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectBuild should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectBuild should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("InspectBuild returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("InspectBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -71,19 +73,21 @@ func TestDocker_SetupBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.SetupBuild(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.SetupBuild(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("SetupBuild should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("SetupBuild should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("SetupBuild returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("SetupBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -103,24 +107,26 @@ func TestDocker_AssembleBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := NewMock()
-		if err != nil {
-			t.Errorf("unable to create runtime engine: %v", err)
-		}
-
-		err = _engine.AssembleBuild(context.Background(), test.pipeline)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("AssembleBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := NewMock()
+			if err != nil {
+				t.Errorf("unable to create runtime engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.AssembleBuild(context.Background(), test.pipeline)
 
-		if err != nil {
-			t.Errorf("AssembleBuild returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("AssembleBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("AssembleBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -140,23 +146,25 @@ func TestDocker_RemoveBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := NewMock()
-		if err != nil {
-			t.Errorf("unable to create runtime engine: %v", err)
-		}
-
-		err = _engine.RemoveBuild(context.Background(), test.pipeline)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("RemoveBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := NewMock()
+			if err != nil {
+				t.Errorf("unable to create runtime engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.RemoveBuild(context.Background(), test.pipeline)
 
-		if err != nil {
-			t.Errorf("RemoveBuild returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("RemoveBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("RemoveBuild returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/docker/container_test.go
+++ b/runtime/docker/container_test.go
@@ -20,14 +20,17 @@ func TestDocker_InspectContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "build container",
 			failure:   false,
 			container: _container,
 		},
 		{
+			name:      "empty build container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -60,18 +63,22 @@ func TestDocker_RemoveContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "build container",
 			failure:   false,
 			container: _container,
 		},
 		{
+			name:      "empty build container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
 		{
+			name:    "absent build container",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_ignorenotfound",
@@ -112,17 +119,20 @@ func TestDocker_RunContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		pipeline  *pipeline.Build
 		container *pipeline.Container
 		volumes   []string
 	}{
 		{
+			name:      "steps-clone step",
 			failure:   false,
 			pipeline:  _pipeline,
 			container: _container,
 		},
 		{
+			name:     "steps-echo step",
 			failure:  false,
 			pipeline: _pipeline,
 			container: &pipeline.Container{
@@ -138,6 +148,7 @@ func TestDocker_RunContainer(t *testing.T) {
 			},
 		},
 		{
+			name:     "steps-privileged",
 			failure:  false,
 			pipeline: _pipeline,
 			container: &pipeline.Container{
@@ -153,6 +164,7 @@ func TestDocker_RunContainer(t *testing.T) {
 			},
 		},
 		{
+			name:     "steps-kaniko-volumes",
 			failure:  false,
 			pipeline: _pipeline,
 			container: &pipeline.Container{
@@ -169,11 +181,13 @@ func TestDocker_RunContainer(t *testing.T) {
 			volumes: []string{"/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:rw"},
 		},
 		{
+			name:      "steps-empty build container",
 			failure:   true,
 			pipeline:  _pipeline,
 			container: new(pipeline.Container),
 		},
 		{
+			name:     "steps-absent build container",
 			failure:  true,
 			pipeline: _pipeline,
 			container: &pipeline.Container{
@@ -187,6 +201,7 @@ func TestDocker_RunContainer(t *testing.T) {
 			},
 		},
 		{
+			name:     "steps-user-absent build container",
 			failure:  true,
 			pipeline: _pipeline,
 			container: &pipeline.Container{
@@ -195,6 +210,23 @@ func TestDocker_RunContainer(t *testing.T) {
 				Environment: map[string]string{"FOO": "bar"},
 				Image:       "target/vela-git:v0.4.0",
 				Name:        "ignorenotfound",
+				Number:      2,
+				Pull:        "always",
+				User:        "foo",
+			},
+		},
+		{
+			name:     "steps-user-echo step",
+			failure:  false,
+			pipeline: _pipeline,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_echo",
+				Commands:    []string{"echo", "hello"},
+				Directory:   "/vela/src/github.com/octocat/helloworld",
+				Environment: map[string]string{"FOO": "bar"},
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Image:       "alpine:latest",
+				Name:        "echo",
 				Number:      2,
 				Pull:        "always",
 				User:        "foo",
@@ -233,14 +265,17 @@ func TestDocker_SetupContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "pull-always-tag_exists",
 			failure:   false,
 			container: _container,
 		},
 		{
+			name:    "pull-not_present-tag_exists",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_clone",
@@ -253,6 +288,7 @@ func TestDocker_SetupContainer(t *testing.T) {
 			},
 		},
 		{
+			name:    "pull-not_present-mock tag ignorenotfound", // mock returns as if this exists
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_clone",
@@ -265,6 +301,7 @@ func TestDocker_SetupContainer(t *testing.T) {
 			},
 		},
 		{
+			name:    "pull-always-tag notfound fails",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_clone",
@@ -277,6 +314,7 @@ func TestDocker_SetupContainer(t *testing.T) {
 			},
 		},
 		{
+			name:    "pull-not_present-tag notfound fails",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_clone",
@@ -317,14 +355,17 @@ func TestDocker_TailContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "build container",
 			failure:   false,
 			container: _container,
 		},
 		{
+			name:      "empty build container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -357,14 +398,17 @@ func TestDocker_WaitContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "build container",
 			failure:   false,
 			container: _container,
 		},
 		{
+			name:      "empty build container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},

--- a/runtime/docker/container_test.go
+++ b/runtime/docker/container_test.go
@@ -38,19 +38,21 @@ func TestDocker_InspectContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.InspectContainer(context.Background(), test.container)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.InspectContainer(context.Background(), test.container)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectContainer should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectContainer should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("InspectContainer returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("InspectContainer returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -94,19 +96,21 @@ func TestDocker_RemoveContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.RemoveContainer(context.Background(), test.container)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.RemoveContainer(context.Background(), test.container)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("RemoveContainer should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("RemoveContainer should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("RemoveContainer returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("RemoveContainer returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -236,23 +240,25 @@ func TestDocker_RunContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		if len(test.volumes) > 0 {
-			_engine.config.Volumes = test.volumes
-		}
-
-		err = _engine.RunContainer(context.Background(), test.container, test.pipeline)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("RunContainer should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			if len(test.volumes) > 0 {
+				_engine.config.Volumes = test.volumes
 			}
 
-			continue
-		}
+			err = _engine.RunContainer(context.Background(), test.container, test.pipeline)
 
-		if err != nil {
-			t.Errorf("RunContainer returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("RunContainer should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("RunContainer returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -330,19 +336,21 @@ func TestDocker_SetupContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.SetupContainer(context.Background(), test.container)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.SetupContainer(context.Background(), test.container)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("SetupContainer should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("SetupContainer should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("SetupContainer returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("SetupContainer returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -373,19 +381,21 @@ func TestDocker_TailContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.TailContainer(context.Background(), test.container)
+		t.Run(test.name, func(t *testing.T) {
+			_, err = _engine.TailContainer(context.Background(), test.container)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("TailContainer should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("TailContainer should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("TailContainer returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("TailContainer returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -416,18 +426,20 @@ func TestDocker_WaitContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.WaitContainer(context.Background(), test.container)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.WaitContainer(context.Background(), test.container)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WaitContainer should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WaitContainer should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("WaitContainer returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WaitContainer returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -38,25 +38,27 @@ func TestDocker_New(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		// patch environment for tests
-		env.PatchAll(t, test.envs)
+		t.Run(test.name, func(t *testing.T) {
+			// patch environment for tests
+			env.PatchAll(t, test.envs)
 
-		_, err := New(
-			WithPrivilegedImages([]string{"alpine"}),
-			WithHostVolumes([]string{"/foo/bar.txt:/foo/bar.txt"}),
-		)
+			_, err := New(
+				WithPrivilegedImages([]string{"alpine"}),
+				WithHostVolumes([]string{"/foo/bar.txt:/foo/bar.txt"}),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("New should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("New should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("New returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("New returned err: %v", err)
+			}
+		})
 	}
 }
 

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -15,14 +15,17 @@ import (
 func TestDocker_New(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		envs    map[string]string
 	}{
 		{
+			name:    "default",
 			failure: false,
 			envs:    map[string]string{},
 		},
 		{
+			name:    "with invalid DOCKER_CERT_PATH",
 			failure: true,
 			envs: map[string]string{
 				"DOCKER_CERT_PATH": "invalid/path",

--- a/runtime/docker/image_test.go
+++ b/runtime/docker/image_test.go
@@ -51,18 +51,20 @@ func TestDocker_InspectImage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.InspectImage(context.Background(), test.container)
+		t.Run(test.name, func(t *testing.T) {
+			_, err = _engine.InspectImage(context.Background(), test.container)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectImage should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectImage should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("InspectImage returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("InspectImage returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/docker/image_test.go
+++ b/runtime/docker/image_test.go
@@ -20,18 +20,22 @@ func TestDocker_InspectImage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "tag exists",
 			failure:   false,
 			container: _container,
 		},
 		{
+			name:      "empty build container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
 		{
+			name:    "tag notfound",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_clone",

--- a/runtime/docker/network_test.go
+++ b/runtime/docker/network_test.go
@@ -38,19 +38,21 @@ func TestDocker_CreateNetwork(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.CreateNetwork(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.CreateNetwork(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateNetwork should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateNetwork should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("CreateNetwork returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("CreateNetwork returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -81,19 +83,21 @@ func TestDocker_InspectNetwork(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.InspectNetwork(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			_, err = _engine.InspectNetwork(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectNetwork should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectNetwork should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("InspectNetwork returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("InspectNetwork returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -124,18 +128,20 @@ func TestDocker_RemoveNetwork(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.RemoveNetwork(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.RemoveNetwork(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("RemoveNetwork should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("RemoveNetwork should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("RemoveNetwork returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("RemoveNetwork returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/docker/network_test.go
+++ b/runtime/docker/network_test.go
@@ -20,14 +20,17 @@ func TestDocker_CreateNetwork(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
 		{
+			name:     "empty",
 			failure:  true,
 			pipeline: new(pipeline.Build),
 		},
@@ -60,14 +63,17 @@ func TestDocker_InspectNetwork(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
 		{
+			name:     "empty",
 			failure:  true,
 			pipeline: new(pipeline.Build),
 		},
@@ -100,14 +106,17 @@ func TestDocker_RemoveNetwork(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
 		{
+			name:     "empty",
 			failure:  true,
 			pipeline: new(pipeline.Build),
 		},

--- a/runtime/docker/opts_test.go
+++ b/runtime/docker/opts_test.go
@@ -32,17 +32,19 @@ func TestDocker_ClientOpt_WithPrivilegedImages(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_service, err := New(
-			WithPrivilegedImages(test.images),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_service, err := New(
+				WithPrivilegedImages(test.images),
+			)
 
-		if err != nil {
-			t.Errorf("WithPrivilegedImages returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WithPrivilegedImages returned err: %v", err)
+			}
 
-		if !reflect.DeepEqual(_service.config.Images, test.want) {
-			t.Errorf("WithPrivilegedImages is %v, want %v", _service.config.Images, test.want)
-		}
+			if !reflect.DeepEqual(_service.config.Images, test.want) {
+				t.Errorf("WithPrivilegedImages is %v, want %v", _service.config.Images, test.want)
+			}
+		})
 	}
 }
 
@@ -67,17 +69,19 @@ func TestDocker_ClientOpt_WithHostVolumes(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_service, err := New(
-			WithHostVolumes(test.volumes),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_service, err := New(
+				WithHostVolumes(test.volumes),
+			)
 
-		if err != nil {
-			t.Errorf("WithHostVolumes returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WithHostVolumes returned err: %v", err)
+			}
 
-		if !reflect.DeepEqual(_service.config.Volumes, test.want) {
-			t.Errorf("WithHostVolumes is %v, want %v", _service.config.Volumes, test.want)
-		}
+			if !reflect.DeepEqual(_service.config.Volumes, test.want) {
+				t.Errorf("WithHostVolumes is %v, want %v", _service.config.Volumes, test.want)
+			}
+		})
 	}
 }
 
@@ -102,28 +106,30 @@ func TestDocker_ClientOpt_WithLogger(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_service, err := New(
-			WithLogger(test.logger),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_service, err := New(
+				WithLogger(test.logger),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithLogger should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithLogger should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithLogger returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithLogger returned err: %v", err)
-		}
+			if test.logger == nil && _service.Logger == nil {
+				t.Errorf("_engine.Logger should not be nil even if nil is passed to WithLogger")
+			}
 
-		if test.logger == nil && _service.Logger == nil {
-			t.Errorf("_engine.Logger should not be nil even if nil is passed to WithLogger")
-		}
-
-		if test.logger != nil && !reflect.DeepEqual(_service.Logger, test.logger) {
-			t.Errorf("WithLogger set %v, want %v", _service.Logger, test.logger)
-		}
+			if test.logger != nil && !reflect.DeepEqual(_service.Logger, test.logger) {
+				t.Errorf("WithLogger set %v, want %v", _service.Logger, test.logger)
+			}
+		})
 	}
 }

--- a/runtime/docker/opts_test.go
+++ b/runtime/docker/opts_test.go
@@ -14,14 +14,17 @@ import (
 func TestDocker_ClientOpt_WithPrivilegedImages(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name   string
 		images []string
 		want   []string
 	}{
 		{
+			name:   "defined",
 			images: []string{"alpine", "golang"},
 			want:   []string{"alpine", "golang"},
 		},
 		{
+			name:   "empty",
 			images: []string{},
 			want:   []string{},
 		},
@@ -46,14 +49,17 @@ func TestDocker_ClientOpt_WithPrivilegedImages(t *testing.T) {
 func TestDocker_ClientOpt_WithHostVolumes(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		volumes []string
 		want    []string
 	}{
 		{
+			name:    "defined",
 			volumes: []string{"/foo/bar.txt:/foo/bar.txt", "/tmp/baz.conf:/tmp/baz.conf"},
 			want:    []string{"/foo/bar.txt:/foo/bar.txt", "/tmp/baz.conf:/tmp/baz.conf"},
 		},
 		{
+			name:    "empty",
 			volumes: []string{},
 			want:    []string{},
 		},
@@ -78,14 +84,17 @@ func TestDocker_ClientOpt_WithHostVolumes(t *testing.T) {
 func TestDocker_ClientOpt_WithLogger(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		logger  *logrus.Entry
 	}{
 		{
+			name:    "provided logger",
 			failure: false,
 			logger:  &logrus.Entry{},
 		},
 		{
+			name:    "nil logger",
 			failure: false,
 			logger:  nil,
 		},

--- a/runtime/docker/volume_test.go
+++ b/runtime/docker/volume_test.go
@@ -20,14 +20,17 @@ func TestDocker_CreateVolume(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
 		{
+			name:     "empty",
 			failure:  true,
 			pipeline: new(pipeline.Build),
 		},
@@ -60,14 +63,17 @@ func TestDocker_InspectVolume(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
 		{
+			name:     "empty",
 			failure:  true,
 			pipeline: new(pipeline.Build),
 		},
@@ -100,14 +106,17 @@ func TestDocker_RemoveVolume(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _pipeline,
 		},
 		{
+			name:     "empty",
 			failure:  true,
 			pipeline: new(pipeline.Build),
 		},

--- a/runtime/docker/volume_test.go
+++ b/runtime/docker/volume_test.go
@@ -38,19 +38,21 @@ func TestDocker_CreateVolume(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.CreateVolume(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.CreateVolume(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateVolume should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateVolume should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("CreateVolume returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("CreateVolume returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -81,19 +83,21 @@ func TestDocker_InspectVolume(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.InspectVolume(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			_, err = _engine.InspectVolume(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectVolume should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectVolume should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("InspectVolume returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("InspectVolume returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -124,18 +128,20 @@ func TestDocker_RemoveVolume(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.RemoveVolume(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.RemoveVolume(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("RemoveVolume should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("RemoveVolume should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("RemoveVolume returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("RemoveVolume returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/kubernetes/build_test.go
+++ b/runtime/kubernetes/build_test.go
@@ -43,19 +43,21 @@ func TestKubernetes_InspectBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.InspectBuild(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			_, err = _engine.InspectBuild(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectBuild should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectBuild should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("InspectBuild returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("InspectBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -287,88 +289,90 @@ func TestKubernetes_SetupBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		// setup types
-		_engine, err := NewMock(&v1.Pod{}, test.opts...)
-		if err != nil {
-			t.Errorf("unable to create runtime engine: %v", err)
-		}
-
-		err = _engine.SetupBuild(context.Background(), test.pipeline)
-
-		// this does not test the resulting pod spec (ie no tests for ObjectMeta, RestartPolicy)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("SetupBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			// setup types
+			_engine, err := NewMock(&v1.Pod{}, test.opts...)
+			if err != nil {
+				t.Errorf("unable to create runtime engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.SetupBuild(context.Background(), test.pipeline)
 
-		if err != nil {
-			t.Errorf("SetupBuild returned err: %v", err)
-		}
+			// this does not test the resulting pod spec (ie no tests for ObjectMeta, RestartPolicy)
 
-		// make sure that worker-defined labels are set and cannot be overridden by PipelinePodsTemplate
-		if pipelineLabel, ok := _engine.Pod.ObjectMeta.Labels["pipeline"]; !ok {
-			t.Errorf("Pod is missing the pipeline label: %v", _engine.Pod.ObjectMeta)
-		} else if pipelineLabel != test.pipeline.ID {
-			t.Errorf("Pod's pipeline label is %v, want %v", pipelineLabel, test.pipeline.ID)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("SetupBuild should have returned err")
+				}
 
-		switch test.wantFromTemplate.(type) {
-		case velav1alpha1.PipelinePodTemplateMeta:
-			want := test.wantFromTemplate.(velav1alpha1.PipelinePodTemplateMeta)
-
-			// PipelinePodsTemplate defined Annotations
-			if want.Annotations != nil && !reflect.DeepEqual(_engine.Pod.Annotations, want.Annotations) {
-				t.Errorf("Pod.Annotations is %v, want %v", _engine.Pod.Annotations, want.Annotations)
+				return // continue to next test
 			}
 
-			// PipelinePodsTemplate defined Labels
-			if want.Labels != nil && !reflect.DeepEqual(_engine.Pod.Labels, want.Labels) {
-				t.Errorf("Pod.Labels is %v, want %v", _engine.Pod.Labels, want.Labels)
-			}
-		case velav1alpha1.PipelinePodSecurityContext:
-			want := test.wantFromTemplate.(velav1alpha1.PipelinePodSecurityContext)
-
-			// PipelinePodsTemplate defined SecurityContext.RunAsNonRoot
-			if !reflect.DeepEqual(_engine.Pod.Spec.SecurityContext.RunAsNonRoot, want.RunAsNonRoot) {
-				t.Errorf("Pod.SecurityContext.RunAsNonRoot is %v, want %v", _engine.Pod.Spec.SecurityContext.RunAsNonRoot, want.RunAsNonRoot)
+			if err != nil {
+				t.Errorf("SetupBuild returned err: %v", err)
 			}
 
-			// PipelinePodsTemplate defined SecurityContext.Sysctls
-			if want.Sysctls != nil && !reflect.DeepEqual(_engine.Pod.Spec.SecurityContext.Sysctls, want.Sysctls) {
-				t.Errorf("Pod.SecurityContext.Sysctls is %v, want %v", _engine.Pod.Spec.SecurityContext.Sysctls, want.Sysctls)
-			}
-		case velav1alpha1.PipelinePodTemplateSpec:
-			want := test.wantFromTemplate.(velav1alpha1.PipelinePodTemplateSpec)
-
-			// PipelinePodsTemplate defined NodeSelector
-			if want.NodeSelector != nil && !reflect.DeepEqual(_engine.Pod.Spec.NodeSelector, want.NodeSelector) {
-				t.Errorf("Pod.NodeSelector is %v, want %v", _engine.Pod.Spec.NodeSelector, want.NodeSelector)
+			// make sure that worker-defined labels are set and cannot be overridden by PipelinePodsTemplate
+			if pipelineLabel, ok := _engine.Pod.ObjectMeta.Labels["pipeline"]; !ok {
+				t.Errorf("Pod is missing the pipeline label: %v", _engine.Pod.ObjectMeta)
+			} else if pipelineLabel != test.pipeline.ID {
+				t.Errorf("Pod's pipeline label is %v, want %v", pipelineLabel, test.pipeline.ID)
 			}
 
-			// PipelinePodsTemplate defined Affinity
-			if want.Affinity != nil && !reflect.DeepEqual(_engine.Pod.Spec.Affinity, want.Affinity) {
-				t.Errorf("Pod.Affinity is %v, want %v", _engine.Pod.Spec.Affinity, want.Affinity)
-			}
+			switch test.wantFromTemplate.(type) {
+			case velav1alpha1.PipelinePodTemplateMeta:
+				want := test.wantFromTemplate.(velav1alpha1.PipelinePodTemplateMeta)
 
-			// PipelinePodsTemplate defined Tolerations
-			if want.Tolerations != nil && !reflect.DeepEqual(_engine.Pod.Spec.Tolerations, want.Tolerations) {
-				t.Errorf("Pod.Tolerations is %v, want %v", _engine.Pod.Spec.Tolerations, want.Tolerations)
-			}
+				// PipelinePodsTemplate defined Annotations
+				if want.Annotations != nil && !reflect.DeepEqual(_engine.Pod.Annotations, want.Annotations) {
+					t.Errorf("Pod.Annotations is %v, want %v", _engine.Pod.Annotations, want.Annotations)
+				}
 
-			// PipelinePodsTemplate defined DNSPolicy
-			if len(want.DNSPolicy) > 0 && _engine.Pod.Spec.DNSPolicy != want.DNSPolicy {
-				t.Errorf("Pod.DNSPolicy is %v, want %v", _engine.Pod.Spec.DNSPolicy, want.DNSPolicy)
-			}
+				// PipelinePodsTemplate defined Labels
+				if want.Labels != nil && !reflect.DeepEqual(_engine.Pod.Labels, want.Labels) {
+					t.Errorf("Pod.Labels is %v, want %v", _engine.Pod.Labels, want.Labels)
+				}
+			case velav1alpha1.PipelinePodSecurityContext:
+				want := test.wantFromTemplate.(velav1alpha1.PipelinePodSecurityContext)
 
-			// PipelinePodsTemplate defined DNSConfig
-			if want.DNSConfig != nil && !reflect.DeepEqual(_engine.Pod.Spec.DNSConfig, want.DNSConfig) {
-				t.Errorf("Pod.DNSConfig is %v, want %v", _engine.Pod.Spec.DNSConfig, want.DNSConfig)
+				// PipelinePodsTemplate defined SecurityContext.RunAsNonRoot
+				if !reflect.DeepEqual(_engine.Pod.Spec.SecurityContext.RunAsNonRoot, want.RunAsNonRoot) {
+					t.Errorf("Pod.SecurityContext.RunAsNonRoot is %v, want %v", _engine.Pod.Spec.SecurityContext.RunAsNonRoot, want.RunAsNonRoot)
+				}
+
+				// PipelinePodsTemplate defined SecurityContext.Sysctls
+				if want.Sysctls != nil && !reflect.DeepEqual(_engine.Pod.Spec.SecurityContext.Sysctls, want.Sysctls) {
+					t.Errorf("Pod.SecurityContext.Sysctls is %v, want %v", _engine.Pod.Spec.SecurityContext.Sysctls, want.Sysctls)
+				}
+			case velav1alpha1.PipelinePodTemplateSpec:
+				want := test.wantFromTemplate.(velav1alpha1.PipelinePodTemplateSpec)
+
+				// PipelinePodsTemplate defined NodeSelector
+				if want.NodeSelector != nil && !reflect.DeepEqual(_engine.Pod.Spec.NodeSelector, want.NodeSelector) {
+					t.Errorf("Pod.NodeSelector is %v, want %v", _engine.Pod.Spec.NodeSelector, want.NodeSelector)
+				}
+
+				// PipelinePodsTemplate defined Affinity
+				if want.Affinity != nil && !reflect.DeepEqual(_engine.Pod.Spec.Affinity, want.Affinity) {
+					t.Errorf("Pod.Affinity is %v, want %v", _engine.Pod.Spec.Affinity, want.Affinity)
+				}
+
+				// PipelinePodsTemplate defined Tolerations
+				if want.Tolerations != nil && !reflect.DeepEqual(_engine.Pod.Spec.Tolerations, want.Tolerations) {
+					t.Errorf("Pod.Tolerations is %v, want %v", _engine.Pod.Spec.Tolerations, want.Tolerations)
+				}
+
+				// PipelinePodsTemplate defined DNSPolicy
+				if len(want.DNSPolicy) > 0 && _engine.Pod.Spec.DNSPolicy != want.DNSPolicy {
+					t.Errorf("Pod.DNSPolicy is %v, want %v", _engine.Pod.Spec.DNSPolicy, want.DNSPolicy)
+				}
+
+				// PipelinePodsTemplate defined DNSConfig
+				if want.DNSConfig != nil && !reflect.DeepEqual(_engine.Pod.Spec.DNSConfig, want.DNSConfig) {
+					t.Errorf("Pod.DNSConfig is %v, want %v", _engine.Pod.Spec.DNSConfig, want.DNSConfig)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -415,26 +419,28 @@ func TestKubernetes_AssembleBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := NewMock(test.k8sPod)
-		_engine.Pod = test.enginePod
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := NewMock(test.k8sPod)
+			_engine.Pod = test.enginePod
 
-		if err != nil {
-			t.Errorf("unable to create runtime engine: %v", err)
-		}
-
-		err = _engine.AssembleBuild(context.Background(), test.pipeline)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("AssembleBuild should have returned err")
+			if err != nil {
+				t.Errorf("unable to create runtime engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.AssembleBuild(context.Background(), test.pipeline)
 
-		if err != nil {
-			t.Errorf("AssembleBuild returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("AssembleBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("AssembleBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -493,24 +499,26 @@ func TestKubernetes_RemoveBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := NewMock(test.pod)
-		if err != nil {
-			t.Errorf("unable to create runtime engine: %v", err)
-		}
-
-		_engine.createdPod = test.createdPod
-
-		err = _engine.RemoveBuild(context.Background(), test.pipeline)
-		if test.failure {
-			if err == nil {
-				t.Errorf("RemoveBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := NewMock(test.pod)
+			if err != nil {
+				t.Errorf("unable to create runtime engine: %v", err)
 			}
 
-			continue
-		}
+			_engine.createdPod = test.createdPod
 
-		if err != nil {
-			t.Errorf("RemoveBuild returned err: %v", err)
-		}
+			err = _engine.RemoveBuild(context.Background(), test.pipeline)
+			if test.failure {
+				if err == nil {
+					t.Errorf("RemoveBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("RemoveBuild returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/kubernetes/build_test.go
+++ b/runtime/kubernetes/build_test.go
@@ -25,14 +25,17 @@ func TestKubernetes_InspectBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "stages",
 			failure:  false,
 			pipeline: _stages,
 		},
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _steps,
 		},
@@ -162,102 +165,119 @@ func TestKubernetes_SetupBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name             string
 		failure          bool
 		pipeline         *pipeline.Build
 		opts             []ClientOpt
 		wantFromTemplate interface{}
 	}{
 		{
+			name:             "stages",
 			failure:          false,
 			pipeline:         _stages,
 			opts:             nil,
 			wantFromTemplate: nil,
 		},
 		{
+			name:             "steps",
 			failure:          false,
 			pipeline:         _steps,
 			opts:             nil,
 			wantFromTemplate: nil,
 		},
 		{
+			name:             "stages-PipelinePodsTemplate-empty",
 			failure:          false,
 			pipeline:         _stages,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-empty.yaml")},
 			wantFromTemplate: nil,
 		},
 		{
+			name:             "steps-PipelinePodsTemplate-empty",
 			failure:          false,
 			pipeline:         _steps,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-empty.yaml")},
 			wantFromTemplate: nil,
 		},
 		{
+			name:             "stages-PipelinePodsTemplate-metadata",
 			failure:          false,
 			pipeline:         _stages,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template.yaml")},
 			wantFromTemplate: wantFromTemplateMetadata,
 		},
 		{
+			name:             "steps-PipelinePodsTemplate-metadata",
 			failure:          false,
 			pipeline:         _steps,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template.yaml")},
 			wantFromTemplate: wantFromTemplateMetadata,
 		},
 		{
+			name:             "stages-PipelinePodsTemplate-SecurityContext",
 			failure:          false,
 			pipeline:         _stages,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-security-context.yaml")},
 			wantFromTemplate: wantFromTemplateSecurityContext,
 		},
 		{
+			name:             "steps-PipelinePodsTemplate-SecurityContext",
 			failure:          false,
 			pipeline:         _steps,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-security-context.yaml")},
 			wantFromTemplate: wantFromTemplateSecurityContext,
 		},
 		{
+			name:             "stages-PipelinePodsTemplate-NodeSelection",
 			failure:          false,
 			pipeline:         _stages,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-node-selection.yaml")},
 			wantFromTemplate: wantFromTemplateNodeSelection,
 		},
 		{
+			name:             "steps-PipelinePodsTemplate-NodeSelection",
 			failure:          false,
 			pipeline:         _steps,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-node-selection.yaml")},
 			wantFromTemplate: wantFromTemplateNodeSelection,
 		},
 		{
+			name:             "stages-PipelinePodsTemplate-dns",
 			failure:          false,
 			pipeline:         _stages,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-dns.yaml")},
 			wantFromTemplate: wantFromTemplateDNS,
 		},
 		{
+			name:             "steps-PipelinePodsTemplate-dns",
 			failure:          false,
 			pipeline:         _steps,
 			opts:             []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-dns.yaml")},
 			wantFromTemplate: wantFromTemplateDNS,
 		},
 		{
+			name:             "stages-named PipelinePodsTemplate present",
 			failure:          false,
 			pipeline:         _stages,
 			opts:             []ClientOpt{WithPodsTemplate("mock-pipeline-pods-template", "")},
 			wantFromTemplate: nil,
 		},
 		{
+			name:             "steps-named PipelinePodsTemplate present",
 			failure:          false,
 			pipeline:         _steps,
 			opts:             []ClientOpt{WithPodsTemplate("mock-pipeline-pods-template", "")},
 			wantFromTemplate: nil,
 		},
 		{
+			name:             "stages-named PipelinePodsTemplate missing",
 			failure:          true,
 			pipeline:         _stages,
 			opts:             []ClientOpt{WithPodsTemplate("missing-pipeline-pods-template", "")},
 			wantFromTemplate: nil,
 		},
 		{
+			name:             "steps-named PipelinePodsTemplate missing",
 			failure:          true,
 			pipeline:         _steps,
 			opts:             []ClientOpt{WithPodsTemplate("missing-pipeline-pods-template", "")},
@@ -355,6 +375,7 @@ func TestKubernetes_SetupBuild(t *testing.T) {
 func TestKubernetes_AssembleBuild(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 		// k8sPod is the pod that the mock Kubernetes client will return
@@ -363,24 +384,28 @@ func TestKubernetes_AssembleBuild(t *testing.T) {
 		enginePod *v1.Pod
 	}{
 		{
+			name:      "stages",
 			failure:   false,
 			pipeline:  _stages,
 			k8sPod:    &v1.Pod{},
 			enginePod: _stagesPod,
 		},
 		{
+			name:      "steps",
 			failure:   false,
 			pipeline:  _steps,
 			k8sPod:    &v1.Pod{},
 			enginePod: _pod,
 		},
 		{
+			name:      "stages-pod already exists",
 			failure:   true,
 			pipeline:  _stages,
 			k8sPod:    _stagesPod,
 			enginePod: _stagesPod,
 		},
 		{
+			name:      "steps-pod already exists",
 			failure:   true,
 			pipeline:  _steps,
 			k8sPod:    _pod,
@@ -416,42 +441,49 @@ func TestKubernetes_AssembleBuild(t *testing.T) {
 func TestKubernetes_RemoveBuild(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name       string
 		failure    bool
 		createdPod bool
 		pipeline   *pipeline.Build
 		pod        *v1.Pod
 	}{
 		{
+			name:       "stages-createdPod-pod in k8s",
 			failure:    false,
 			createdPod: true,
 			pipeline:   _stages,
 			pod:        _pod,
 		},
 		{
+			name:       "steps-createdPod-pod in k8s",
 			failure:    false,
 			createdPod: true,
 			pipeline:   _steps,
 			pod:        _pod,
 		},
 		{
+			name:       "stages-not createdPod-pod not in k8s",
 			failure:    false,
 			createdPod: false,
 			pipeline:   _stages,
 			pod:        &v1.Pod{},
 		},
 		{
+			name:       "steps-not createdPod-pod not in k8s",
 			failure:    false,
 			pipeline:   _steps,
 			pod:        &v1.Pod{},
 			createdPod: false,
 		},
 		{
+			name:       "stages-createdPod-pod not in k8s",
 			failure:    true,
 			pipeline:   _stages,
 			pod:        &v1.Pod{},
 			createdPod: true,
 		},
 		{
+			name:       "steps-createdPod-pod not in k8s",
 			failure:    true,
 			pipeline:   _steps,
 			pod:        &v1.Pod{},

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -26,14 +26,17 @@ func TestKubernetes_InspectContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "build container",
 			failure:   false,
 			container: _container,
 		},
 		{
+			name:      "empty build container",
 			failure:   false,
 			container: new(pipeline.Container),
 		},
@@ -66,10 +69,12 @@ func TestKubernetes_RemoveContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "build container",
 			failure:   false,
 			container: _container,
 		},
@@ -97,6 +102,7 @@ func TestKubernetes_RunContainer(t *testing.T) {
 	// TODO: include VolumeMounts?
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 		pipeline  *pipeline.Build
@@ -104,12 +110,14 @@ func TestKubernetes_RunContainer(t *testing.T) {
 		volumes   []string
 	}{
 		{
+			name:      "stages",
 			failure:   false,
 			container: _container,
 			pipeline:  _stages,
 			pod:       _pod,
 		},
 		{
+			name:      "steps",
 			failure:   false,
 			container: _container,
 			pipeline:  _steps,
@@ -147,6 +155,7 @@ func TestKubernetes_RunContainer(t *testing.T) {
 func TestKubernetes_SetupContainer(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name             string
 		failure          bool
 		container        *pipeline.Container
 		opts             []ClientOpt
@@ -154,13 +163,15 @@ func TestKubernetes_SetupContainer(t *testing.T) {
 		wantFromTemplate interface{}
 	}{
 		{
+			name:             "step-clone",
 			failure:          false,
-			container:        _container,
+			container:        _container, // clone step
 			opts:             nil,
 			wantPrivileged:   false,
 			wantFromTemplate: nil,
 		},
 		{
+			name:    "step-echo",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -178,6 +189,7 @@ func TestKubernetes_SetupContainer(t *testing.T) {
 			wantFromTemplate: nil,
 		},
 		{
+			name:    "privileged",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -195,6 +207,7 @@ func TestKubernetes_SetupContainer(t *testing.T) {
 			wantFromTemplate: nil,
 		},
 		{
+			name:           "PipelinePodsTemplate",
 			failure:        false,
 			container:      _container,
 			opts:           []ClientOpt{WithPodsTemplate("", "testdata/pipeline-pods-template-security-context.yaml")},
@@ -282,16 +295,19 @@ func TestKubernetes_TailContainer(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "got logs",
 			failure:   false,
 			container: _container,
 		},
 		// We cannot test failures, because the mock GetLogs() always
 		// returns a successful response with logs body: "fake logs"
 		//{
+		//	name:      "empty build container",
 		//	failure:   true,
 		//	container: new(pipeline.Container),
 		//},
@@ -318,16 +334,19 @@ func TestKubernetes_TailContainer(t *testing.T) {
 func TestKubernetes_WaitContainer(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 		object    runtime.Object
 	}{
 		{
+			name:      "default order in ContainerStatuses",
 			failure:   false,
 			container: _container,
 			object:    _pod,
 		},
 		{
+			name:      "inverted order in ContainerStatuses",
 			failure:   false,
 			container: _container,
 			object: &v1.Pod{
@@ -368,6 +387,7 @@ func TestKubernetes_WaitContainer(t *testing.T) {
 			},
 		},
 		{
+			name:      "watch returns invalid type",
 			failure:   true,
 			container: _container,
 			object:    new(v1.PodTemplate),

--- a/runtime/kubernetes/image_test.go
+++ b/runtime/kubernetes/image_test.go
@@ -33,18 +33,20 @@ func TestKubernetes_InspectImage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.InspectImage(context.Background(), test.container)
+		t.Run(test.name, func(t *testing.T) {
+			_, err = _engine.InspectImage(context.Background(), test.container)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectImage should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectImage should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("InspectImage returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("InspectImage returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/kubernetes/image_test.go
+++ b/runtime/kubernetes/image_test.go
@@ -20,10 +20,12 @@ func TestKubernetes_InspectImage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:      "valid image",
 			failure:   false,
 			container: _container,
 		},

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -19,16 +19,19 @@ import (
 func TestKubernetes_New(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		namespace string
 		path      string
 	}{
 		{
+			name:      "valid config file",
 			failure:   false,
 			namespace: "test",
 			path:      "testdata/config",
 		},
 		{
+			name:      "invalid config file",
 			failure:   true,
 			namespace: "test",
 			path:      "testdata/config_empty",
@@ -38,6 +41,7 @@ func TestKubernetes_New(t *testing.T) {
 		// run in kubernetes, so we would need a way to mock the
 		// return value of rest.InClusterConfig(), but how?
 		//{
+		//	name:      "InClusterConfig file",
 		//	failure:   false,
 		//	namespace: "test",
 		//	path:      "",

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -50,22 +50,24 @@ func TestKubernetes_New(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err := New(
-			WithConfigFile(test.path),
-			WithNamespace(test.namespace),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_, err := New(
+				WithConfigFile(test.path),
+				WithNamespace(test.namespace),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("New should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("New should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("New returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("New returned err: %v", err)
+			}
+		})
 	}
 }
 

--- a/runtime/kubernetes/network_test.go
+++ b/runtime/kubernetes/network_test.go
@@ -38,19 +38,21 @@ func TestKubernetes_CreateNetwork(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := _engine.CreateNetwork(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err := _engine.CreateNetwork(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateNetwork should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateNetwork should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("CreateNetwork returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("CreateNetwork returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -81,19 +83,21 @@ func TestKubernetes_InspectNetwork(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err = _engine.InspectNetwork(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			_, err = _engine.InspectNetwork(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectNetwork should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectNetwork should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("InspectNetwork returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("InspectNetwork returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -124,18 +128,20 @@ func TestKubernetes_RemoveNetwork(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.RemoveNetwork(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.RemoveNetwork(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("RemoveNetwork should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("RemoveNetwork should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("RemoveNetwork returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("RemoveNetwork returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/kubernetes/network_test.go
+++ b/runtime/kubernetes/network_test.go
@@ -20,14 +20,17 @@ func TestKubernetes_CreateNetwork(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "stages",
 			failure:  false,
 			pipeline: _stages,
 		},
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _steps,
 		},
@@ -60,14 +63,17 @@ func TestKubernetes_InspectNetwork(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "stages",
 			failure:  false,
 			pipeline: _stages,
 		},
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _steps,
 		},
@@ -100,14 +106,17 @@ func TestKubernetes_RemoveNetwork(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "stages",
 			failure:  false,
 			pipeline: _stages,
 		},
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _steps,
 		},

--- a/runtime/kubernetes/opts_test.go
+++ b/runtime/kubernetes/opts_test.go
@@ -16,16 +16,31 @@ import (
 func TestKubernetes_ClientOpt_WithConfigFile(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		file    string
 		want    string
 	}{
 		{
+			name:    "valid config file",
 			failure: false,
 			file:    "testdata/config",
 			want:    "testdata/config",
 		},
 		{
+			name:    "invalid config file",
+			failure: true,
+			file:    "testdata/config_empty",
+			want:    "testdata/config_empty",
+		},
+		{
+			name:    "missing config file",
+			failure: true,
+			file:    "testdata/config_missing",
+			want:    "testdata/config_missing",
+		},
+		{
+			name:    "InClusterConfig file missing",
 			failure: true,
 			file:    "",
 			want:    "",
@@ -59,16 +74,19 @@ func TestKubernetes_ClientOpt_WithConfigFile(t *testing.T) {
 func TestKubernetes_ClientOpt_WithNamespace(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		namespace string
 		want      string
 	}{
 		{
+			name:      "namespace",
 			failure:   false,
 			namespace: "foo",
 			want:      "foo",
 		},
 		{
+			name:      "empty namespace fails",
 			failure:   true,
 			namespace: "",
 			want:      "",
@@ -103,14 +121,17 @@ func TestKubernetes_ClientOpt_WithNamespace(t *testing.T) {
 func TestKubernetes_ClientOpt_WithHostVolumes(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		volumes []string
 		want    []string
 	}{
 		{
+			name:    "defined",
 			volumes: []string{"/foo/bar.txt:/foo/bar.txt", "/tmp/baz.conf:/tmp/baz.conf"},
 			want:    []string{"/foo/bar.txt:/foo/bar.txt", "/tmp/baz.conf:/tmp/baz.conf"},
 		},
 		{
+			name:    "empty",
 			volumes: []string{},
 			want:    []string{},
 		},
@@ -136,14 +157,17 @@ func TestKubernetes_ClientOpt_WithHostVolumes(t *testing.T) {
 func TestKubernetes_ClientOpt_WithPrivilegedImages(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name   string
 		images []string
 		want   []string
 	}{
 		{
+			name:   "defined",
 			images: []string{"alpine", "golang"},
 			want:   []string{"alpine", "golang"},
 		},
 		{
+			name:   "empty",
 			images: []string{},
 			want:   []string{},
 		},
@@ -169,14 +193,17 @@ func TestKubernetes_ClientOpt_WithPrivilegedImages(t *testing.T) {
 func TestKubernetes_ClientOpt_WithLogger(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		logger  *logrus.Entry
 	}{
 		{
+			name:    "provided logger",
 			failure: false,
 			logger:  &logrus.Entry{},
 		},
 		{
+			name:    "nil logger",
 			failure: false,
 			logger:  nil,
 		},
@@ -214,6 +241,7 @@ func TestKubernetes_ClientOpt_WithLogger(t *testing.T) {
 func TestKubernetes_ClientOpt_WithPodsTemplate(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name             string
 		failure          bool
 		podsTemplateName string
 		podsTemplatePath string
@@ -221,6 +249,7 @@ func TestKubernetes_ClientOpt_WithPodsTemplate(t *testing.T) {
 		wantTemplate     *velav1alpha1.PipelinePodTemplate
 	}{
 		{
+			name:             "name",
 			failure:          false,
 			podsTemplateName: "foo-bar-name",
 			podsTemplatePath: "",
@@ -228,6 +257,7 @@ func TestKubernetes_ClientOpt_WithPodsTemplate(t *testing.T) {
 			wantTemplate:     nil,
 		},
 		{
+			name:             "no name or path",
 			failure:          false,
 			podsTemplateName: "",
 			podsTemplatePath: "",
@@ -235,6 +265,7 @@ func TestKubernetes_ClientOpt_WithPodsTemplate(t *testing.T) {
 			wantTemplate:     nil,
 		},
 		{
+			name:             "ignores missing files",
 			failure:          false, // ignores missing files; can be added later
 			podsTemplateName: "",
 			podsTemplatePath: "testdata/does-not-exist.yaml",
@@ -242,6 +273,7 @@ func TestKubernetes_ClientOpt_WithPodsTemplate(t *testing.T) {
 			wantTemplate:     nil,
 		},
 		{
+			name:             "path-empty",
 			failure:          false,
 			podsTemplateName: "",
 			podsTemplatePath: "testdata/pipeline-pods-template-empty.yaml",
@@ -249,6 +281,7 @@ func TestKubernetes_ClientOpt_WithPodsTemplate(t *testing.T) {
 			wantTemplate:     &velav1alpha1.PipelinePodTemplate{},
 		},
 		{
+			name:             "path",
 			failure:          false,
 			podsTemplateName: "",
 			podsTemplatePath: "testdata/pipeline-pods-template.yaml",
@@ -264,6 +297,7 @@ func TestKubernetes_ClientOpt_WithPodsTemplate(t *testing.T) {
 			},
 		},
 		{
+			name:             "path-malformed",
 			failure:          true,
 			podsTemplateName: "",
 			podsTemplatePath: "testdata/pipeline-pods-template-malformed.yaml",

--- a/runtime/kubernetes/opts_test.go
+++ b/runtime/kubernetes/opts_test.go
@@ -49,25 +49,27 @@ func TestKubernetes_ClientOpt_WithConfigFile(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithConfigFile(test.file),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithConfigFile(test.file),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithConfigFile should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithConfigFile should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithConfigFile returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithConfigFile returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.config.File, test.want) {
-			t.Errorf("WithConfigFile is %v, want %v", _engine.config.File, test.want)
-		}
+			if !reflect.DeepEqual(_engine.config.File, test.want) {
+				t.Errorf("WithConfigFile is %v, want %v", _engine.config.File, test.want)
+			}
+		})
 	}
 }
 
@@ -95,26 +97,28 @@ func TestKubernetes_ClientOpt_WithNamespace(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithConfigFile("testdata/config"),
-			WithNamespace(test.namespace),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithConfigFile("testdata/config"),
+				WithNamespace(test.namespace),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithNamespace should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithNamespace should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithNamespace returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithNamespace returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.config.Namespace, test.want) {
-			t.Errorf("WithNamespace is %v, want %v", _engine.config.Namespace, test.want)
-		}
+			if !reflect.DeepEqual(_engine.config.Namespace, test.want) {
+				t.Errorf("WithNamespace is %v, want %v", _engine.config.Namespace, test.want)
+			}
+		})
 	}
 }
 
@@ -139,18 +143,20 @@ func TestKubernetes_ClientOpt_WithHostVolumes(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithConfigFile("testdata/config"),
-			WithHostVolumes(test.volumes),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithConfigFile("testdata/config"),
+				WithHostVolumes(test.volumes),
+			)
 
-		if err != nil {
-			t.Errorf("WithHostVolumes returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WithHostVolumes returned err: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.config.Volumes, test.want) {
-			t.Errorf("WithHostVolumes is %v, want %v", _engine.config.Volumes, test.want)
-		}
+			if !reflect.DeepEqual(_engine.config.Volumes, test.want) {
+				t.Errorf("WithHostVolumes is %v, want %v", _engine.config.Volumes, test.want)
+			}
+		})
 	}
 }
 
@@ -175,18 +181,20 @@ func TestKubernetes_ClientOpt_WithPrivilegedImages(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithConfigFile("testdata/config"),
-			WithPrivilegedImages(test.images),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithConfigFile("testdata/config"),
+				WithPrivilegedImages(test.images),
+			)
 
-		if err != nil {
-			t.Errorf("WithPrivilegedImages returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WithPrivilegedImages returned err: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.config.Images, test.want) {
-			t.Errorf("WithPrivilegedImages is %v, want %v", _engine.config.Images, test.want)
-		}
+			if !reflect.DeepEqual(_engine.config.Images, test.want) {
+				t.Errorf("WithPrivilegedImages is %v, want %v", _engine.config.Images, test.want)
+			}
+		})
 	}
 }
 
@@ -211,30 +219,32 @@ func TestKubernetes_ClientOpt_WithLogger(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithConfigFile("testdata/config"),
-			WithLogger(test.logger),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithConfigFile("testdata/config"),
+				WithLogger(test.logger),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithLogger should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithLogger should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithLogger returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithLogger returned err: %v", err)
-		}
+			if test.logger == nil && _engine.Logger == nil {
+				t.Errorf("_engine.Logger should not be nil even if nil is passed to WithLogger")
+			}
 
-		if test.logger == nil && _engine.Logger == nil {
-			t.Errorf("_engine.Logger should not be nil even if nil is passed to WithLogger")
-		}
-
-		if test.logger != nil && !reflect.DeepEqual(_engine.Logger, test.logger) {
-			t.Errorf("WithLogger set %v, want %v", _engine.Logger, test.logger)
-		}
+			if test.logger != nil && !reflect.DeepEqual(_engine.Logger, test.logger) {
+				t.Errorf("WithLogger set %v, want %v", _engine.Logger, test.logger)
+			}
+		})
 	}
 }
 
@@ -308,30 +318,32 @@ func TestKubernetes_ClientOpt_WithPodsTemplate(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithConfigFile("testdata/config"),
-			WithNamespace("foo"),
-			WithPodsTemplate(test.podsTemplateName, test.podsTemplatePath),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithConfigFile("testdata/config"),
+				WithNamespace("foo"),
+				WithPodsTemplate(test.podsTemplateName, test.podsTemplatePath),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithPodsTemplate should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithPodsTemplate should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithPodsTemplate returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithPodsTemplate returned err: %v", err)
-		}
+			if !reflect.DeepEqual(_engine.config.PipelinePodsTemplateName, test.wantName) {
+				t.Errorf("WithPodsTemplate is %v, wantName %v", _engine.config.PipelinePodsTemplateName, test.wantName)
+			}
 
-		if !reflect.DeepEqual(_engine.config.PipelinePodsTemplateName, test.wantName) {
-			t.Errorf("WithPodsTemplate is %v, wantName %v", _engine.config.PipelinePodsTemplateName, test.wantName)
-		}
-
-		if test.wantTemplate != nil && !reflect.DeepEqual(_engine.PipelinePodTemplate, test.wantTemplate) {
-			t.Errorf("WithPodsTemplate is %v, wantTemplate %v", _engine.PipelinePodTemplate, test.wantTemplate)
-		}
+			if test.wantTemplate != nil && !reflect.DeepEqual(_engine.PipelinePodTemplate, test.wantTemplate) {
+				t.Errorf("WithPodsTemplate is %v, wantTemplate %v", _engine.PipelinePodTemplate, test.wantTemplate)
+			}
+		})
 	}
 }

--- a/runtime/kubernetes/volume_test.go
+++ b/runtime/kubernetes/volume_test.go
@@ -22,14 +22,17 @@ func TestKubernetes_CreateVolume(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "stages",
 			failure:  false,
 			pipeline: _stages,
 		},
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _steps,
 		},
@@ -56,16 +59,19 @@ func TestKubernetes_CreateVolume(t *testing.T) {
 func TestKubernetes_InspectVolume(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 		pod      *v1.Pod
 	}{
 		{
+			name:     "stages",
 			failure:  false,
 			pipeline: _stages,
 			pod:      _pod,
 		},
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _steps,
 			pod:      _pod,
@@ -104,14 +110,17 @@ func TestKubernetes_RemoveVolume(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "stages",
 			failure:  false,
 			pipeline: _stages,
 		},
 		{
+			name:     "steps",
 			failure:  false,
 			pipeline: _steps,
 		},

--- a/runtime/kubernetes/volume_test.go
+++ b/runtime/kubernetes/volume_test.go
@@ -40,19 +40,21 @@ func TestKubernetes_CreateVolume(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.CreateVolume(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.CreateVolume(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateVolume should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateVolume should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("CreateVolume returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("CreateVolume returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -80,24 +82,26 @@ func TestKubernetes_InspectVolume(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := NewMock(test.pod)
-		if err != nil {
-			t.Errorf("unable to create runtime engine: %v", err)
-		}
-
-		_, err = _engine.InspectVolume(context.Background(), test.pipeline)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("InspectVolume should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := NewMock(test.pod)
+			if err != nil {
+				t.Errorf("unable to create runtime engine: %v", err)
 			}
 
-			continue
-		}
+			_, err = _engine.InspectVolume(context.Background(), test.pipeline)
 
-		if err != nil {
-			t.Errorf("InspectVolume returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("InspectVolume should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("InspectVolume returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -128,18 +132,20 @@ func TestKubernetes_RemoveVolume(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = _engine.RemoveVolume(context.Background(), test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			err = _engine.RemoveVolume(context.Background(), test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("RemoveVolume should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("RemoveVolume should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("RemoveVolume returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("RemoveVolume returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -13,16 +13,19 @@ import (
 func TestRuntime_New(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		setup   *Setup
 	}{
 		{
+			name:    "docker driver",
 			failure: false,
 			setup: &Setup{
 				Driver: constants.DriverDocker,
 			},
 		},
 		{
+			name:    "kubernetes driver",
 			failure: false,
 			setup: &Setup{
 				Driver:     constants.DriverKubernetes,
@@ -31,12 +34,14 @@ func TestRuntime_New(t *testing.T) {
 			},
 		},
 		{
+			name:    "invalid driver fails",
 			failure: true,
 			setup: &Setup{
 				Driver: "invalid",
 			},
 		},
 		{
+			name:    "empty driver fails",
 			failure: true,
 			setup: &Setup{
 				Driver: "",

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -51,18 +51,20 @@ func TestRuntime_New(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err := New(test.setup)
+		t.Run(test.name, func(t *testing.T) {
+			_, err := New(test.setup)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("New should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("New should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("New returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("New returned err: %v", err)
+			}
+		})
 	}
 }

--- a/runtime/setup_test.go
+++ b/runtime/setup_test.go
@@ -41,17 +41,20 @@ func TestRuntime_Setup_Kubernetes(t *testing.T) {
 func TestRuntime_Validate(t *testing.T) {
 	// setup types
 	tests := []struct {
+		name    string
 		failure bool
 		setup   *Setup
 		want    error
 	}{
 		{
+			name:    "docker driver",
 			failure: false,
 			setup: &Setup{
 				Driver: constants.DriverDocker,
 			},
 		},
 		{
+			name:    "kubernetes driver",
 			failure: false,
 			setup: &Setup{
 				Driver:    constants.DriverKubernetes,
@@ -59,12 +62,14 @@ func TestRuntime_Validate(t *testing.T) {
 			},
 		},
 		{
+			name:    "empty driver",
 			failure: true,
 			setup: &Setup{
 				Driver: "",
 			},
 		},
 		{
+			name:    "kubernetes driver-missing namespace",
 			failure: true,
 			setup: &Setup{
 				Driver: constants.DriverKubernetes,

--- a/runtime/setup_test.go
+++ b/runtime/setup_test.go
@@ -79,18 +79,20 @@ func TestRuntime_Validate(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := test.setup.Validate()
+		t.Run(test.name, func(t *testing.T) {
+			err := test.setup.Validate()
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("Validate should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("Validate should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("Validate returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("Validate returned err: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
I use Goland to run `go test`. At least with Goland, `testing.Run()` improves the output and test selection. And it makes it easier to see which subtest has failed.

As I develop and refactor, I would really like to see this everywhere. This starts with all tests under `runtime/`.
After this is merged I can prepare another one that does `executor/`.