### PR TITLE
refactor: cleanup context passing in kubernetes runtime

### DIFF
--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -45,10 +45,9 @@ func (c *client) SetupBuild(ctx context.Context, b *pipeline.Build) error {
 
 	if c.PipelinePodTemplate == nil {
 		if len(c.config.PipelinePodsTemplateName) > 0 {
-			// nolint: contextcheck // ignore non-inherited new context
-			podsTemplateResponse, err := c.VelaKubernetes.VelaV1alpha1().PipelinePodsTemplates(c.config.Namespace).Get(
-				context.Background(), c.config.PipelinePodsTemplateName, metav1.GetOptions{},
-			)
+			podsTemplateResponse, err := c.VelaKubernetes.VelaV1alpha1().
+				PipelinePodsTemplates(c.config.Namespace).
+				Get(ctx, c.config.PipelinePodsTemplateName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -192,10 +191,9 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 	// send API call to create the pod
 	//
 	// https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1?tab=doc#PodInterface
-	// nolint: contextcheck // ignore non-inherited new context
 	_, err = c.Kubernetes.CoreV1().
 		Pods(c.config.Namespace).
-		Create(context.Background(), c.Pod, metav1.CreateOptions{})
+		Create(ctx, c.Pod, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -233,10 +231,9 @@ func (c *client) RemoveBuild(ctx context.Context, b *pipeline.Build) error {
 
 	c.Logger.Infof("removing pod %s", c.Pod.ObjectMeta.Name)
 	// send API call to delete the pod
-	// nolint: contextcheck // ignore non-inherited new context
 	err := c.Kubernetes.CoreV1().
 		Pods(c.config.Namespace).
-		Delete(context.Background(), c.Pod.ObjectMeta.Name, opts)
+		Delete(ctx, c.Pod.ObjectMeta.Name, opts)
 	if err != nil {
 		return err
 	}

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -34,12 +34,9 @@ func (c *client) InspectContainer(ctx context.Context, ctn *pipeline.Container) 
 	// send API call to capture the container
 	//
 	// https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1?tab=doc#PodInterface
-	// nolint: contextcheck // ignore non-inherited new context
-	pod, err := c.Kubernetes.CoreV1().Pods(c.config.Namespace).Get(
-		context.Background(),
-		c.Pod.ObjectMeta.Name,
-		opts,
-	)
+	pod, err := c.Kubernetes.CoreV1().
+		Pods(c.config.Namespace).
+		Get(ctx, c.Pod.ObjectMeta.Name, opts)
 	if err != nil {
 		return err
 	}
@@ -105,9 +102,8 @@ func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *p
 	// send API call to patch the pod with the new container image
 	//
 	// https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1?tab=doc#PodInterface
-	// nolint: contextcheck // ignore non-inherited new context
 	_, err = c.Kubernetes.CoreV1().Pods(c.config.Namespace).Patch(
-		context.Background(),
+		ctx,
 		c.Pod.ObjectMeta.Name,
 		types.StrategicMergePatchType,
 		[]byte(fmt.Sprintf(imagePatch, ctn.ID, _image)),
@@ -342,8 +338,9 @@ func (c *client) WaitContainer(ctx context.Context, ctn *pipeline.Container) err
 	// https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1?tab=doc#PodInterface
 	// ->
 	// https://pkg.go.dev/k8s.io/apimachinery/pkg/watch?tab=doc#Interface
-	// nolint: contextcheck // ignore non-inherited new context
-	podWatch, err := c.Kubernetes.CoreV1().Pods(c.config.Namespace).Watch(context.Background(), opts)
+	podWatch, err := c.Kubernetes.CoreV1().
+		Pods(c.config.Namespace).
+		Watch(ctx, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The API calls in the kubernetes runtime all use `context.Background()`. They should use the passed context instead.

Extracted from #304 so it can be reviewed separately.
