### PR TITLE
tests: Convert executor tests to subtests

### DIFF
--- a/executor/context_test.go
+++ b/executor/context_test.go
@@ -76,11 +76,13 @@ func TestExecutor_FromContext(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := FromContext(test.context)
+		t.Run(test.name, func(t *testing.T) {
+			got := FromContext(test.context)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("FromContext is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("FromContext is %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 
@@ -141,15 +143,17 @@ func TestExecutor_FromGinContext(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		if test.value != nil {
-			test.context.Set(key, test.value)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			if test.value != nil {
+				test.context.Set(key, test.value)
+			}
 
-		got := FromGinContext(test.context)
+			got := FromGinContext(test.context)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("FromGinContext is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("FromGinContext is %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 

--- a/executor/context_test.go
+++ b/executor/context_test.go
@@ -51,19 +51,23 @@ func TestExecutor_FromContext(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		context context.Context
 		want    Engine
 	}{
 		{
+			name: "valid executor in context",
 			// nolint: staticcheck,revive // ignore using string with context value
 			context: context.WithValue(context.Background(), key, _engine),
 			want:    _engine,
 		},
 		{
+			name:    "executor not in context",
 			context: context.Background(),
 			want:    nil,
 		},
 		{
+			name: "invalid executor in context",
 			// nolint: staticcheck,revive // ignore using string with context value
 			context: context.WithValue(context.Background(), key, "foo"),
 			want:    nil,
@@ -110,21 +114,25 @@ func TestExecutor_FromGinContext(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		context *gin.Context
 		value   interface{}
 		want    Engine
 	}{
 		{
+			name:    "valid executor in context",
 			context: new(gin.Context),
 			value:   _engine,
 			want:    _engine,
 		},
 		{
+			name:    "executor not in context",
 			context: new(gin.Context),
 			value:   nil,
 			want:    nil,
 		},
 		{
+			name:    "invalid executor in context",
 			context: new(gin.Context),
 			value:   "foo",
 			want:    nil,

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -174,27 +174,29 @@ func TestExecutor_New(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := New(test.setup)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := New(test.setup)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("New should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("New should have returned err")
+				}
+
+				if !reflect.DeepEqual(got, test.want) {
+					t.Errorf("New is %v, want %v", got, test.want)
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("New returned err: %v", err)
 			}
 
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("New is %v, want %v", got, test.want)
 			}
-
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("New returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("New is %v, want %v", got, test.want)
-		}
+		})
 	}
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -73,11 +73,13 @@ func TestExecutor_New(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		setup   *Setup
 		want    Engine
 	}{
 		{
+			name:    "driver-darwin",
 			failure: true,
 			setup: &Setup{
 				Build:    _build,
@@ -92,6 +94,7 @@ func TestExecutor_New(t *testing.T) {
 			want: nil,
 		},
 		{
+			name:    "driver-linux",
 			failure: false,
 			setup: &Setup{
 				Build:      _build,
@@ -108,6 +111,7 @@ func TestExecutor_New(t *testing.T) {
 			want: _linux,
 		},
 		{
+			name:    "driver-local",
 			failure: false,
 			setup: &Setup{
 				Build:    _build,
@@ -122,6 +126,7 @@ func TestExecutor_New(t *testing.T) {
 			want: _local,
 		},
 		{
+			name:    "driver-windows",
 			failure: true,
 			setup: &Setup{
 				Build:    _build,
@@ -136,6 +141,7 @@ func TestExecutor_New(t *testing.T) {
 			want: nil,
 		},
 		{
+			name:    "driver-invalid",
 			failure: true,
 			setup: &Setup{
 				Build:    _build,
@@ -150,6 +156,7 @@ func TestExecutor_New(t *testing.T) {
 			want: nil,
 		},
 		{
+			name:    "driver-empty",
 			failure: true,
 			setup: &Setup{
 				Build:    _build,

--- a/executor/linux/api_test.go
+++ b/executor/linux/api_test.go
@@ -40,23 +40,25 @@ func TestLinux_GetBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := test.engine.GetBuild()
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.engine.GetBuild()
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("GetBuild should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("GetBuild should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("GetBuild returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("GetBuild returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, _build) {
-			t.Errorf("GetBuild is %v, want %v", got, _build)
-		}
+			if !reflect.DeepEqual(got, _build) {
+				t.Errorf("GetBuild is %v, want %v", got, _build)
+			}
+		})
 	}
 }
 
@@ -91,23 +93,25 @@ func TestLinux_GetPipeline(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := test.engine.GetPipeline()
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.engine.GetPipeline()
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("GetPipeline should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("GetPipeline should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("GetPipeline returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("GetPipeline returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, _steps) {
-			t.Errorf("GetPipeline is %v, want %v", got, _steps)
-		}
+			if !reflect.DeepEqual(got, _steps) {
+				t.Errorf("GetPipeline is %v, want %v", got, _steps)
+			}
+		})
 	}
 }
 
@@ -142,22 +146,24 @@ func TestLinux_GetRepo(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := test.engine.GetRepo()
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.engine.GetRepo()
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("GetRepo should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("GetRepo should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("GetRepo returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("GetRepo returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, _repo) {
-			t.Errorf("GetRepo is %v, want %v", got, _repo)
-		}
+			if !reflect.DeepEqual(got, _repo) {
+				t.Errorf("GetRepo is %v, want %v", got, _repo)
+			}
+		})
 	}
 }

--- a/executor/linux/api_test.go
+++ b/executor/linux/api_test.go
@@ -22,14 +22,17 @@ func TestLinux_GetBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		engine  *client
 	}{
 		{
+			name:    "with build",
 			failure: false,
 			engine:  _engine,
 		},
 		{
+			name:    "missing build",
 			failure: true,
 			engine:  new(client),
 		},
@@ -70,14 +73,17 @@ func TestLinux_GetPipeline(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		engine  *client
 	}{
 		{
+			name:    "with pipeline",
 			failure: false,
 			engine:  _engine,
 		},
 		{
+			name:    "missing pipeline",
 			failure: true,
 			engine:  new(client),
 		},
@@ -118,14 +124,17 @@ func TestLinux_GetRepo(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		engine  *client
 	}{
 		{
+			name:    "with repo",
 			failure: false,
 			engine:  _engine,
 		},
 		{
+			name:    "missing repo",
 			failure: true,
 			engine:  new(client),
 		},

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -86,41 +86,43 @@ func TestLinux_CreateBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithMetadata(_metadata).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(test.build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.CreateBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithMetadata(_metadata).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(test.build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("CreateBuild returned err: %v", err)
-		}
+			err = _engine.CreateBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("CreateBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -176,47 +178,49 @@ func TestLinux_PlanBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithMetadata(_metadata).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		err = _engine.PlanBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("PlanBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithMetadata(_metadata).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("PlanBuild returned err: %v", err)
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
+
+			err = _engine.PlanBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("PlanBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("PlanBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -312,47 +316,49 @@ func TestLinux_AssembleBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithMetadata(_metadata).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		err = _engine.AssembleBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("AssembleBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithMetadata(_metadata).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("AssembleBuild returned err: %v", err)
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
+
+			err = _engine.AssembleBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("AssembleBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("AssembleBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -418,81 +424,83 @@ func TestLinux_ExecBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithMetadata(_metadata).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		// TODO: hack - remove this
-		//
-		// When using our Docker mock we default the list of
-		// Docker images that have privileged access. One of
-		// these images is target/vela-git which is injected
-		// by the compiler into every build.
-		//
-		// The problem this causes is that we haven't called
-		// all the necessary functions we do in a real world
-		// scenario to ensure we can run privileged images.
-		//
-		// This is the necessary function to create the
-		// runtime host config so we can run images
-		// in a privileged fashion.
-		err = _runtime.CreateVolume(context.Background(), _pipeline)
-		if err != nil {
-			t.Errorf("unable to create runtime volume: %v", err)
-		}
-
-		// TODO: hack - remove this
-		//
-		// When calling CreateBuild(), it will automatically set the
-		// test build object to a status of `created`. This happens
-		// because we use a mock for the go-vela/server in our tests
-		// which only returns dummy based responses.
-		//
-		// The problem this causes is that our container.Execute()
-		// function isn't setup to handle builds in a `created` state.
-		//
-		// In a real world scenario, we never would have a build
-		// in this state when we call ExecBuild() because the
-		// go-vela/server has logic to set it to an expected state.
-		_engine.build.SetStatus("running")
-
-		err = _engine.ExecBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("ExecBuild for %s should have returned err", test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithMetadata(_metadata).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("ExecBuild for %s returned err: %v", test.pipeline, err)
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
+
+			// TODO: hack - remove this
+			//
+			// When using our Docker mock we default the list of
+			// Docker images that have privileged access. One of
+			// these images is target/vela-git which is injected
+			// by the compiler into every build.
+			//
+			// The problem this causes is that we haven't called
+			// all the necessary functions we do in a real world
+			// scenario to ensure we can run privileged images.
+			//
+			// This is the necessary function to create the
+			// runtime host config so we can run images
+			// in a privileged fashion.
+			err = _runtime.CreateVolume(context.Background(), _pipeline)
+			if err != nil {
+				t.Errorf("unable to create runtime volume: %v", err)
+			}
+
+			// TODO: hack - remove this
+			//
+			// When calling CreateBuild(), it will automatically set the
+			// test build object to a status of `created`. This happens
+			// because we use a mock for the go-vela/server in our tests
+			// which only returns dummy based responses.
+			//
+			// The problem this causes is that our container.Execute()
+			// function isn't setup to handle builds in a `created` state.
+			//
+			// In a real world scenario, we never would have a build
+			// in this state when we call ExecBuild() because the
+			// go-vela/server has logic to set it to an expected state.
+			_engine.build.SetStatus("running")
+
+			err = _engine.ExecBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("ExecBuild for %s should have returned err", test.pipeline)
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ExecBuild for %s returned err: %v", test.pipeline, err)
+			}
+		})
 	}
 }
 
@@ -568,46 +576,48 @@ func TestLinux_DestroyBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithMetadata(_metadata).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		err = _engine.DestroyBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("DestroyBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithMetadata(_metadata).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("DestroyBuild returned err: %v", err)
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
+
+			err = _engine.DestroyBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("DestroyBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("DestroyBuild returned err: %v", err)
+			}
+		})
 	}
 }

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -47,31 +47,37 @@ func TestLinux_CreateBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		build    *library.Build
 		pipeline string
 	}{
-		{ // basic secrets pipeline
+		{
+			name:     "basic secrets pipeline",
 			failure:  false,
 			build:    _build,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			build:    _build,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			build:    _build,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			build:    _build,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		{ // steps pipeline with empty build
+		{
+			name:     "steps pipeline with empty build",
 			failure:  true,
 			build:    new(library.Build),
 			pipeline: "testdata/build/steps/basic.yml",
@@ -142,22 +148,27 @@ func TestLinux_PlanBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic secrets pipeline
+		{
+			name:     "basic secrets pipeline",
 			failure:  false,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
@@ -233,54 +244,67 @@ func TestLinux_AssembleBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic secrets pipeline
+		{
+			name:     "basic secrets pipeline",
 			failure:  false,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
-		{ // secrets pipeline with image not found
+		{
+			name:     "secrets pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/secrets/img_notfound.yml",
 		},
-		{ // secrets pipeline with ignoring image not found
+		{
+			name:     "secrets pipeline with ignoring image not found",
 			failure:  true,
 			pipeline: "testdata/build/secrets/img_ignorenotfound.yml",
 		},
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // services pipeline with image not found
+		{
+			name:     "services pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/services/img_notfound.yml",
 		},
-		{ // services pipeline with ignoring image not found
+		{
+			name:     "services pipeline with ignoring image not found",
 			failure:  true,
 			pipeline: "testdata/build/services/img_ignorenotfound.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // steps pipeline with image not found
+		{
+			name:     "steps pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/steps/img_notfound.yml",
 		},
-		{ // steps pipeline with ignoring image not found
+		{
+			name:     "steps pipeline with ignoring image not found",
 			failure:  true,
 			pipeline: "testdata/build/steps/img_ignorenotfound.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		{ // stages pipeline with image not found
+		{
+			name:     "stages pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/stages/img_notfound.yml",
 		},
-		{ // stages pipeline with ignoring image not found
+		{
+			name:     "stages pipeline with ignoring image not found",
 			failure:  true,
 			pipeline: "testdata/build/stages/img_ignorenotfound.yml",
 		},
@@ -356,30 +380,37 @@ func TestLinux_ExecBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // services pipeline with image not found
+		{
+			name:     "services pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/services/img_notfound.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // steps pipeline with image not found
+		{
+			name:     "steps pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/steps/img_notfound.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		{ // stages pipeline with image not found
+		{
+			name:     "stages pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/stages/img_notfound.yml",
 		},
@@ -489,38 +520,47 @@ func TestLinux_DestroyBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic secrets pipeline
+		{
+			name:     "basic secrets pipeline",
 			failure:  false,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
-		{ // secrets pipeline with name not found
+		{
+			name:     "secrets pipeline with name not found",
 			failure:  false,
 			pipeline: "testdata/build/secrets/name_notfound.yml",
 		},
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // services pipeline with name not found
+		{
+			name:     "services pipeline with name not found",
 			failure:  false,
 			pipeline: "testdata/build/services/name_notfound.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // steps pipeline with name not found
+		{
+			name:     "steps pipeline with name not found",
 			failure:  false,
 			pipeline: "testdata/build/steps/name_notfound.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		{ // stages pipeline with name not found
+		{
+			name:     "stages pipeline with name not found",
 			failure:  false,
 			pipeline: "testdata/build/stages/name_notfound.yml",
 		},

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -39,14 +39,17 @@ func TestLinux_New(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		build   *library.Build
 	}{
 		{
+			name:    "with build",
 			failure: false,
 			build:   testBuild(),
 		},
 		{
+			name:    "nil build",
 			failure: true,
 			build:   nil,
 		},

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -57,27 +57,29 @@ func TestLinux_New(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err := New(
-			WithBuild(test.build),
-			WithHostname("localhost"),
-			WithPipeline(testSteps()),
-			WithRepo(testRepo()),
-			WithRuntime(_runtime),
-			WithUser(testUser()),
-			WithVelaClient(_client),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_, err := New(
+				WithBuild(test.build),
+				WithHostname("localhost"),
+				WithPipeline(testSteps()),
+				WithRepo(testRepo()),
+				WithRuntime(_runtime),
+				WithUser(testUser()),
+				WithVelaClient(_client),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("New should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("New should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("New returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("New returned err: %v", err)
+			}
+		})
 	}
 }
 

--- a/executor/linux/opts_test.go
+++ b/executor/linux/opts_test.go
@@ -46,25 +46,27 @@ func TestLinux_Opt_WithBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(test.build),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(test.build),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithBuild should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithBuild should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithBuild returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithBuild returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.build, _build) {
-			t.Errorf("WithBuild is %v, want %v", _engine.build, _build)
-		}
+			if !reflect.DeepEqual(_engine.build, _build) {
+				t.Errorf("WithBuild is %v, want %v", _engine.build, _build)
+			}
+		})
 	}
 }
 
@@ -94,25 +96,27 @@ func TestLinux_Opt_WithLogMethod(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithLogMethod(test.logMethod),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithLogMethod(test.logMethod),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithLogMethod should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithLogMethod should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithLogMethod returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithLogMethod returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.logMethod, test.logMethod) {
-			t.Errorf("WithLogMethod is %v, want %v", _engine.logMethod, test.logMethod)
-		}
+			if !reflect.DeepEqual(_engine.logMethod, test.logMethod) {
+				t.Errorf("WithLogMethod is %v, want %v", _engine.logMethod, test.logMethod)
+			}
+		})
 	}
 }
 
@@ -132,25 +136,27 @@ func TestLinux_Opt_WithMaxLogSize(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithMaxLogSize(test.maxLogSize),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithMaxLogSize(test.maxLogSize),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithMaxLogSize should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithMaxLogSize should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithMaxLogSize returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithMaxLogSize returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.maxLogSize, test.maxLogSize) {
-			t.Errorf("WithMaxLogSize is %v, want %v", _engine.maxLogSize, test.maxLogSize)
-		}
+			if !reflect.DeepEqual(_engine.maxLogSize, test.maxLogSize) {
+				t.Errorf("WithMaxLogSize is %v, want %v", _engine.maxLogSize, test.maxLogSize)
+			}
+		})
 	}
 }
 func TestLinux_Opt_WithHostname(t *testing.T) {
@@ -174,16 +180,18 @@ func TestLinux_Opt_WithHostname(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithHostname(test.hostname),
-		)
-		if err != nil {
-			t.Errorf("unable to create linux engine: %v", err)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithHostname(test.hostname),
+			)
+			if err != nil {
+				t.Errorf("unable to create linux engine: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.Hostname, test.want) {
-			t.Errorf("WithHostname is %v, want %v", _engine.Hostname, test.want)
-		}
+			if !reflect.DeepEqual(_engine.Hostname, test.want) {
+				t.Errorf("WithHostname is %v, want %v", _engine.Hostname, test.want)
+			}
+		})
 	}
 }
 
@@ -211,25 +219,27 @@ func TestLinux_Opt_WithPipeline(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithPipeline(test.pipeline),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithPipeline(test.pipeline),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithPipeline should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithPipeline should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithPipeline returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithPipeline returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.pipeline, _steps) {
-			t.Errorf("WithPipeline is %v, want %v", _engine.pipeline, _steps)
-		}
+			if !reflect.DeepEqual(_engine.pipeline, _steps) {
+				t.Errorf("WithPipeline is %v, want %v", _engine.pipeline, _steps)
+			}
+		})
 	}
 }
 
@@ -257,25 +267,27 @@ func TestLinux_Opt_WithRepo(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithRepo(test.repo),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithRepo(test.repo),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithRepo should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithRepo should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithRepo returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithRepo returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.repo, _repo) {
-			t.Errorf("WithRepo is %v, want %v", _engine.repo, _repo)
-		}
+			if !reflect.DeepEqual(_engine.repo, _repo) {
+				t.Errorf("WithRepo is %v, want %v", _engine.repo, _repo)
+			}
+		})
 	}
 }
 
@@ -306,25 +318,27 @@ func TestLinux_Opt_WithRuntime(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithRuntime(test.runtime),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithRuntime(test.runtime),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithRuntime should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithRuntime should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithRuntime returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithRuntime returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.Runtime, _runtime) {
-			t.Errorf("WithRuntime is %v, want %v", _engine.Runtime, _runtime)
-		}
+			if !reflect.DeepEqual(_engine.Runtime, _runtime) {
+				t.Errorf("WithRuntime is %v, want %v", _engine.Runtime, _runtime)
+			}
+		})
 	}
 }
 
@@ -352,25 +366,27 @@ func TestLinux_Opt_WithUser(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithUser(test.user),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithUser(test.user),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithUser should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithUser should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithUser returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithUser returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.user, _user) {
-			t.Errorf("WithUser is %v, want %v", _engine.user, _user)
-		}
+			if !reflect.DeepEqual(_engine.user, _user) {
+				t.Errorf("WithUser is %v, want %v", _engine.user, _user)
+			}
+		})
 	}
 }
 
@@ -405,25 +421,27 @@ func TestLinux_Opt_WithVelaClient(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithVelaClient(test.client),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithVelaClient(test.client),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithVelaClient should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithVelaClient should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithVelaClient returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithVelaClient returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.Vela, _client) {
-			t.Errorf("WithVelaClient is %v, want %v", _engine.Vela, _client)
-		}
+			if !reflect.DeepEqual(_engine.Vela, _client) {
+				t.Errorf("WithVelaClient is %v, want %v", _engine.Vela, _client)
+			}
+		})
 	}
 }
 
@@ -448,15 +466,17 @@ func TestLinux_Opt_WithVersion(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithVersion(test.version),
-		)
-		if err != nil {
-			t.Errorf("unable to create linux engine: %v", err)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithVersion(test.version),
+			)
+			if err != nil {
+				t.Errorf("unable to create linux engine: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.Version, test.want) {
-			t.Errorf("WithVersion is %v, want %v", _engine.Version, test.want)
-		}
+			if !reflect.DeepEqual(_engine.Version, test.want) {
+				t.Errorf("WithVersion is %v, want %v", _engine.Version, test.want)
+			}
+		})
 	}
 }

--- a/executor/linux/opts_test.go
+++ b/executor/linux/opts_test.go
@@ -28,14 +28,17 @@ func TestLinux_Opt_WithBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		build   *library.Build
 	}{
 		{
+			name:    "build",
 			failure: false,
 			build:   _build,
 		},
 		{
+			name:    "nil build",
 			failure: true,
 			build:   nil,
 		},
@@ -68,18 +71,22 @@ func TestLinux_Opt_WithBuild(t *testing.T) {
 func TestLinux_Opt_WithLogMethod(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		logMethod string
 	}{
 		{
+			name:      "byte-chunks",
 			failure:   false,
 			logMethod: "byte-chunks",
 		},
 		{
+			name:      "time-chunks",
 			failure:   false,
 			logMethod: "time-chunks",
 		},
 		{
+			name:      "empty",
 			failure:   true,
 			logMethod: "",
 		},
@@ -112,10 +119,12 @@ func TestLinux_Opt_WithLogMethod(t *testing.T) {
 func TestLinux_Opt_WithMaxLogSize(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name       string
 		failure    bool
 		maxLogSize uint
 	}{
 		{
+			name:       "defined",
 			failure:    false,
 			maxLogSize: 2097152,
 		},
@@ -147,14 +156,17 @@ func TestLinux_Opt_WithMaxLogSize(t *testing.T) {
 func TestLinux_Opt_WithHostname(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name     string
 		hostname string
 		want     string
 	}{
 		{
+			name:     "dns hostname",
 			hostname: "vela.worker.localhost",
 			want:     "vela.worker.localhost",
 		},
 		{
+			name:     "empty hostname is localhost",
 			hostname: "",
 			want:     "localhost",
 		},
@@ -181,14 +193,17 @@ func TestLinux_Opt_WithPipeline(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps pipeline",
 			failure:  false,
 			pipeline: _steps,
 		},
 		{
+			name:     "nil pipeline",
 			failure:  true,
 			pipeline: nil,
 		},
@@ -224,14 +239,17 @@ func TestLinux_Opt_WithRepo(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		repo    *library.Repo
 	}{
 		{
+			name:    "repo",
 			failure: false,
 			repo:    _repo,
 		},
 		{
+			name:    "nil repo",
 			failure: true,
 			repo:    nil,
 		},
@@ -270,14 +288,17 @@ func TestLinux_Opt_WithRuntime(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		runtime runtime.Engine
 	}{
 		{
+			name:    "docker runtime",
 			failure: false,
 			runtime: _runtime,
 		},
 		{
+			name:    "nil runtime",
 			failure: true,
 			runtime: nil,
 		},
@@ -313,14 +334,17 @@ func TestLinux_Opt_WithUser(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		user    *library.User
 	}{
 		{
+			name:    "user",
 			failure: false,
 			user:    _user,
 		},
 		{
+			name:    "nil user",
 			failure: true,
 			user:    nil,
 		},
@@ -363,14 +387,17 @@ func TestLinux_Opt_WithVelaClient(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		client  *vela.Client
 	}{
 		{
+			name:    "vela client",
 			failure: false,
 			client:  _client,
 		},
 		{
+			name:    "nil vela client",
 			failure: true,
 			client:  nil,
 		},
@@ -403,14 +430,17 @@ func TestLinux_Opt_WithVelaClient(t *testing.T) {
 func TestLinux_Opt_WithVersion(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		version string
 		want    string
 	}{
 		{
+			name:    "version",
 			version: "v1.0.0",
 			want:    "v1.0.0",
 		},
 		{
+			name:    "empty version",
 			version: "",
 			want:    "v0.0.0",
 		},

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -51,10 +51,12 @@ func TestLinux_Secret_create(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
 		{
+			name:    "good image tag",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_vault",
@@ -67,6 +69,7 @@ func TestLinux_Secret_create(t *testing.T) {
 			},
 		},
 		{
+			name:    "notfound image tag",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_vault",
@@ -138,11 +141,13 @@ func TestLinux_Secret_delete(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 		step      *library.Step
 	}{
 		{
+			name:    "running container-empty step",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_vault",
@@ -156,6 +161,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 			step: new(library.Step),
 		},
 		{
+			name:    "running container-pending step",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_vault",
@@ -169,6 +175,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 			step: _step,
 		},
 		{
+			name:    "inspecting container failure due to invalid container id",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_notfound",
@@ -182,6 +189,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 			step: new(library.Step),
 		},
 		{
+			name:    "removing container failure",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_ignorenotfound",
@@ -255,14 +263,17 @@ func TestLinux_Secret_exec(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic secrets pipeline
+		{
+			name:     "basic secrets pipeline",
 			failure:  false,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
-		{ // pipeline with secret name not found
+		{
+			name:     "pipeline with secret name not found",
 			failure:  true,
 			pipeline: "testdata/build/secrets/name_notfound.yml",
 		},
@@ -334,10 +345,12 @@ func TestLinux_Secret_pull(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		secret  *pipeline.Secret
 	}{
-		{ // success with org secret
+		{
+			name:    "success with org secret",
 			failure: false,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -348,7 +361,8 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // failure with invalid org secret
+		{
+			name:    "failure with invalid org secret",
 			failure: true,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -359,7 +373,8 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // failure with org secret key not found
+		{
+			name:    "failure with org secret key not found",
 			failure: true,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -370,7 +385,8 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // success with repo secret
+		{
+			name:    "success with repo secret",
 			failure: false,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -381,7 +397,8 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // failure with invalid repo secret
+		{
+			name:    "failure with invalid repo secret",
 			failure: true,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -392,7 +409,8 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // failure with repo secret key not found
+		{
+			name:    "failure with repo secret key not found",
 			failure: true,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -403,7 +421,8 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // success with shared secret
+		{
+			name:    "success with shared secret",
 			failure: false,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -414,7 +433,8 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // failure with shared secret key not found
+		{
+			name:    "failure with shared secret key not found",
 			failure: true,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -425,7 +445,8 @@ func TestLinux_Secret_pull(t *testing.T) {
 				Origin: &pipeline.Container{},
 			},
 		},
-		{ // failure with invalid type
+		{
+			name:    "failure with invalid type",
 			failure: true,
 			secret: &pipeline.Secret{
 				Name:   "foo",
@@ -491,11 +512,13 @@ func TestLinux_Secret_stream(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		logs      *library.Log
 		container *pipeline.Container
 	}{
-		{ // container step succeeds
+		{
+			name:    "container step succeeds",
 			failure: false,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
@@ -508,7 +531,8 @@ func TestLinux_Secret_stream(t *testing.T) {
 				Pull:        "always",
 			},
 		},
-		{ // container step fails because of invalid container id
+		{
+			name:    "container step fails because of invalid container id",
 			failure: true,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
@@ -562,12 +586,14 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 
 	// setup types
 	tests := []struct {
+		name string
 		step *pipeline.Container
 		msec map[string]*library.Secret
 		want *pipeline.Container
 	}{
 		// Tests for secrets with image ACLs
 		{
+			name: "secret with empty image ACL not injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: make(map[string]string),
@@ -580,6 +606,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with matching image ACL injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: make(map[string]string),
@@ -592,6 +619,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with matching image:tag ACL injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: make(map[string]string),
@@ -604,6 +632,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with non-matching image ACL not injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: make(map[string]string),
@@ -618,6 +647,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 
 		// Tests for secrets with event ACLs
 		{ // push event checks
+			name: "secret with matching push event ACL injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "push"},
@@ -630,6 +660,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with non-matching push event ACL not injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "push"},
@@ -642,6 +673,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{ // pull_request event checks
+			name: "secret with matching pull_request event ACL injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "pull_request"},
@@ -654,6 +686,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with non-matching pull_request event ACL not injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "pull_request"},
@@ -666,6 +699,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{ // tag event checks
+			name: "secret with matching tag event ACL injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "tag"},
@@ -678,6 +712,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with non-matching tag event ACL not injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "tag"},
@@ -690,6 +725,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{ // deployment event checks
+			name: "secret with matching deployment event ACL injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "deployment"},
@@ -702,6 +738,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with non-matching deployment event ACL not injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "deployment"},
@@ -716,6 +753,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 
 		// Tests for secrets with event and image ACLs
 		{
+			name: "secret with matching event ACL and non-matching image ACL not injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "push"},
@@ -728,6 +766,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with non-matching event ACL and matching image ACL not injected",
 			step: &pipeline.Container{
 				Image:       "centos:latest",
 				Environment: map[string]string{"BUILD_EVENT": "push"},
@@ -740,6 +779,7 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 			},
 		},
 		{
+			name: "secret with matching event ACL and matching image ACL injected",
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
 				Environment: map[string]string{"BUILD_EVENT": "push"},
@@ -778,15 +818,17 @@ func TestLinux_Secret_escapeNewlineSecrets(t *testing.T) {
 
 	// setup types
 	tests := []struct {
+		name      string
 		secretMap map[string]*library.Secret
 		want      map[string]*library.Secret
 	}{
-
 		{
+			name:      "not escaped",
 			secretMap: map[string]*library.Secret{"FOO": {Name: &n, Value: &v}},
 			want:      map[string]*library.Secret{"FOO": {Name: &n, Value: &w}},
 		},
 		{
+			name:      "already escaped",
 			secretMap: map[string]*library.Secret{"FOO": {Name: &n, Value: &vEscaped}},
 			want:      map[string]*library.Secret{"FOO": {Name: &n, Value: &w}},
 		},

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -85,31 +85,33 @@ func TestLinux_Secret_create(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_steps),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.secret.create(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("create should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_steps),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.secret.create(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("create returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("create should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("create returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -206,35 +208,37 @@ func TestLinux_Secret_delete(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_steps),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		_ = _engine.CreateBuild(context.Background())
-
-		_engine.steps.Store(test.container.ID, test.step)
-
-		err = _engine.secret.destroy(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("destroy should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_steps),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			_ = _engine.CreateBuild(context.Background())
 
-		if err != nil {
-			t.Errorf("destroy returned err: %v", err)
-		}
+			_engine.steps.Store(test.container.ID, test.step)
+
+			err = _engine.secret.destroy(context.Background(), test.container)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("destroy should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("destroy returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -281,45 +285,47 @@ func TestLinux_Secret_exec(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		file, _ := ioutil.ReadFile(test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			file, _ := ioutil.ReadFile(test.pipeline)
 
-		p, _ := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithUser(_user).
-			WithMetadata(_metadata).
-			Compile(file)
+			p, _ := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithUser(_user).
+				WithMetadata(_metadata).
+				Compile(file)
 
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(p),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		_engine.build.SetStatus(constants.StatusSuccess)
-
-		// add init container info to client
-		_ = _engine.CreateBuild(context.Background())
-
-		err = _engine.secret.exec(context.Background(), &p.Secrets)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("exec should have returned err")
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(p),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			_engine.build.SetStatus(constants.StatusSuccess)
 
-		if err != nil {
-			t.Errorf("exec returned err: %v", err)
-		}
+			// add init container info to client
+			_ = _engine.CreateBuild(context.Background())
+
+			err = _engine.secret.exec(context.Background(), &p.Secrets)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("exec should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("exec returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -461,31 +467,33 @@ func TestLinux_Secret_pull(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(testSteps()),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		_, err = _engine.secret.pull(test.secret)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("pull should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(testSteps()),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			_, err = _engine.secret.pull(test.secret)
 
-		if err != nil {
-			t.Errorf("pull returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("pull should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("pull returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -549,34 +557,36 @@ func TestLinux_Secret_stream(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_steps),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// add init container info to client
-		_ = _engine.CreateBuild(context.Background())
-
-		err = _engine.secret.stream(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("stream should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_steps),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			// add init container info to client
+			_ = _engine.CreateBuild(context.Background())
 
-		if err != nil {
-			t.Errorf("stream returned err: %v", err)
-		}
+			err = _engine.secret.stream(context.Background(), test.container)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("stream should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("stream returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -795,15 +805,17 @@ func TestLinux_Secret_injectSecret(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_ = injectSecrets(test.step, test.msec)
-		got := test.step
+		t.Run(test.name, func(t *testing.T) {
+			_ = injectSecrets(test.step, test.msec)
+			got := test.step
 
-		// Preferred use of reflect.DeepEqual(x, y interface) is giving false positives.
-		// Switching to a Google library for increased clarity.
-		// https://github.com/google/go-cmp
-		if diff := cmp.Diff(test.want.Environment, got.Environment); diff != "" {
-			t.Errorf("injectSecrets mismatch (-want +got):\n%s", diff)
-		}
+			// Preferred use of reflect.DeepEqual(x, y interface) is giving false positives.
+			// Switching to a Google library for increased clarity.
+			// https://github.com/google/go-cmp
+			if diff := cmp.Diff(test.want.Environment, got.Environment); diff != "" {
+				t.Errorf("injectSecrets mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -836,14 +848,16 @@ func TestLinux_Secret_escapeNewlineSecrets(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		escapeNewlineSecrets(test.secretMap)
-		got := test.secretMap
+		t.Run(test.name, func(t *testing.T) {
+			escapeNewlineSecrets(test.secretMap)
+			got := test.secretMap
 
-		// Preferred use of reflect.DeepEqual(x, y interface) is giving false positives.
-		// Switching to a Google library for increased clarity.
-		// https://github.com/google/go-cmp
-		if diff := cmp.Diff(test.want, got); diff != "" {
-			t.Errorf("escapeNewlineSecrets mismatch (-want +got):\n%s", diff)
-		}
+			// Preferred use of reflect.DeepEqual(x, y interface) is giving false positives.
+			// Switching to a Google library for increased clarity.
+			// https://github.com/google/go-cmp
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("escapeNewlineSecrets mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/executor/linux/service_test.go
+++ b/executor/linux/service_test.go
@@ -86,31 +86,33 @@ func TestLinux_CreateService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.CreateService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.CreateService(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("CreateService returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("CreateService returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -179,31 +181,33 @@ func TestLinux_PlanService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.PlanService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("PlanService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.PlanService(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("PlanService returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("PlanService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("PlanService returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -272,36 +276,38 @@ func TestLinux_ExecService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		if !test.container.Empty() {
-			_engine.services.Store(test.container.ID, new(library.Service))
-			_engine.serviceLogs.Store(test.container.ID, new(library.Log))
-		}
-
-		err = _engine.ExecService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("ExecService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			if !test.container.Empty() {
+				_engine.services.Store(test.container.ID, new(library.Service))
+				_engine.serviceLogs.Store(test.container.ID, new(library.Log))
+			}
 
-		if err != nil {
-			t.Errorf("ExecService returned err: %v", err)
-		}
+			err = _engine.ExecService(context.Background(), test.container)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("ExecService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ExecService returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -370,36 +376,38 @@ func TestLinux_StreamService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		if !test.container.Empty() {
-			_engine.services.Store(test.container.ID, new(library.Service))
-			_engine.serviceLogs.Store(test.container.ID, new(library.Log))
-		}
-
-		err = _engine.StreamService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("StreamService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			if !test.container.Empty() {
+				_engine.services.Store(test.container.ID, new(library.Service))
+				_engine.serviceLogs.Store(test.container.ID, new(library.Log))
+			}
 
-		if err != nil {
-			t.Errorf("StreamService returned err: %v", err)
-		}
+			err = _engine.StreamService(context.Background(), test.container)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("StreamService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("StreamService returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -463,30 +471,32 @@ func TestLinux_DestroyService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.DestroyService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("DestroyService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.DestroyService(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("DestroyService returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("DestroyService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("DestroyService returned err: %v", err)
+			}
+		})
 	}
 }

--- a/executor/linux/service_test.go
+++ b/executor/linux/service_test.go
@@ -43,10 +43,12 @@ func TestLinux_CreateService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -60,7 +62,8 @@ func TestLinux_CreateService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // service container with image not found
+		{
+			name:    "service container with image not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -74,7 +77,8 @@ func TestLinux_CreateService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty service container
+		{
+			name:      "empty service container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -132,10 +136,12 @@ func TestLinux_PlanService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -149,7 +155,8 @@ func TestLinux_PlanService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // service container with nil environment
+		{
+			name:    "service container with nil environment",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -163,7 +170,8 @@ func TestLinux_PlanService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty service container
+		{
+			name:      "empty service container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -221,10 +229,12 @@ func TestLinux_ExecService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -238,7 +248,8 @@ func TestLinux_ExecService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // service container with image not found
+		{
+			name:    "service container with image not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -252,7 +263,8 @@ func TestLinux_ExecService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty service container
+		{
+			name:      "empty service container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -315,10 +327,12 @@ func TestLinux_StreamService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -332,7 +346,8 @@ func TestLinux_StreamService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // service container with name not found
+		{
+			name:    "service container with name not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_notfound",
@@ -346,7 +361,8 @@ func TestLinux_StreamService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty service container
+		{
+			name:      "empty service container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -409,10 +425,12 @@ func TestLinux_DestroyService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -426,7 +444,8 @@ func TestLinux_DestroyService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // service container with ignoring name not found
+		{
+			name:    "service container with ignoring name not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_ignorenotfound",

--- a/executor/linux/stage_test.go
+++ b/executor/linux/stage_test.go
@@ -61,10 +61,12 @@ func TestLinux_CreateStage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		stage   *pipeline.Stage
 	}{
-		{ // basic stage
+		{
+			name:    "basic stage",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -81,7 +83,8 @@ func TestLinux_CreateStage(t *testing.T) {
 				},
 			},
 		},
-		{ // stage with step container with image not found
+		{
+			name:    "stage with step container with image not found",
 			failure: true,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -98,7 +101,8 @@ func TestLinux_CreateStage(t *testing.T) {
 				},
 			},
 		},
-		{ // empty stage
+		{
+			name:    "empty stage",
 			failure: true,
 			stage:   new(pipeline.Stage),
 		},
@@ -178,11 +182,13 @@ func TestLinux_PlanStage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		stage    *pipeline.Stage
 		stageMap *sync.Map
 	}{
-		{ // basic stage
+		{
+			name:    "basic stage",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -200,7 +206,8 @@ func TestLinux_PlanStage(t *testing.T) {
 			},
 			stageMap: new(sync.Map),
 		},
-		{ // basic stage with nil stage map
+		{
+			name:    "basic stage with nil stage map",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name:  "echo",
@@ -219,7 +226,8 @@ func TestLinux_PlanStage(t *testing.T) {
 			},
 			stageMap: testMap,
 		},
-		{ // basic stage with error stage map
+		{
+			name:    "basic stage with error stage map",
 			failure: true,
 			stage: &pipeline.Stage{
 				Name:  "echo",
@@ -292,10 +300,12 @@ func TestLinux_ExecStage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		stage   *pipeline.Stage
 	}{
-		{ // basic stage
+		{
+			name:    "basic stage",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -312,7 +322,8 @@ func TestLinux_ExecStage(t *testing.T) {
 				},
 			},
 		},
-		{ // stage with step container with image not found
+		{
+			name:    "stage with step container with image not found",
 			failure: true,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -329,7 +340,8 @@ func TestLinux_ExecStage(t *testing.T) {
 				},
 			},
 		},
-		{ // stage with step container with bad number
+		{
+			name:    "stage with step container with bad number",
 			failure: true,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -403,10 +415,12 @@ func TestLinux_DestroyStage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		stage   *pipeline.Stage
 	}{
-		{ // basic stage
+		{
+			name:    "basic stage",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name: "echo",

--- a/executor/linux/stage_test.go
+++ b/executor/linux/stage_test.go
@@ -110,39 +110,41 @@ func TestLinux_CreateStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		if len(test.stage.Name) > 0 {
-			// run create to init steps to be created properly
-			err = _engine.CreateBuild(context.Background())
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
 			if err != nil {
-				t.Errorf("unable to create build: %v", err)
-			}
-		}
-
-		err = _engine.CreateStage(context.Background(), test.stage)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateStage should have returned err")
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			if len(test.stage.Name) > 0 {
+				// run create to init steps to be created properly
+				err = _engine.CreateBuild(context.Background())
+				if err != nil {
+					t.Errorf("unable to create build: %v", err)
+				}
+			}
 
-		if err != nil {
-			t.Errorf("CreateStage returned err: %v", err)
-		}
+			err = _engine.CreateStage(context.Background(), test.stage)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateStage should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("CreateStage returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -250,31 +252,33 @@ func TestLinux_PlanStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.PlanStage(context.Background(), test.stage, test.stageMap)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("PlanStage should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.PlanStage(context.Background(), test.stage, test.stageMap)
 
-		if err != nil {
-			t.Errorf("PlanStage returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("PlanStage should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("PlanStage returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -362,34 +366,36 @@ func TestLinux_ExecStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		stageMap := new(sync.Map)
-		stageMap.Store("echo", make(chan error, 1))
+		t.Run(test.name, func(t *testing.T) {
+			stageMap := new(sync.Map)
+			stageMap.Store("echo", make(chan error, 1))
 
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.ExecStage(context.Background(), test.stage, stageMap)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("ExecStage should have returned err")
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.ExecStage(context.Background(), test.stage, stageMap)
 
-		if err != nil {
-			t.Errorf("ExecStage returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("ExecStage should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ExecStage returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -441,30 +447,32 @@ func TestLinux_DestroyStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.DestroyStage(context.Background(), test.stage)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("DestroyStage should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.DestroyStage(context.Background(), test.stage)
 
-		if err != nil {
-			t.Errorf("DestroyStage returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("DestroyStage should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("DestroyStage returned err: %v", err)
+			}
+		})
 	}
 }

--- a/executor/linux/step_test.go
+++ b/executor/linux/step_test.go
@@ -97,31 +97,33 @@ func TestLinux_CreateStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.CreateStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.CreateStep(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("CreateStep returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("CreateStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -186,31 +188,33 @@ func TestLinux_PlanStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.PlanStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("PlanStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.PlanStep(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("PlanStep returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("PlanStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("PlanStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -302,36 +306,38 @@ func TestLinux_ExecStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		if !test.container.Empty() {
-			_engine.steps.Store(test.container.ID, new(library.Step))
-			_engine.stepLogs.Store(test.container.ID, new(library.Log))
-		}
-
-		err = _engine.ExecStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("ExecStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			if !test.container.Empty() {
+				_engine.steps.Store(test.container.ID, new(library.Step))
+				_engine.stepLogs.Store(test.container.ID, new(library.Log))
+			}
 
-		if err != nil {
-			t.Errorf("ExecStep returned err: %v", err)
-		}
+			err = _engine.ExecStep(context.Background(), test.container)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("ExecStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ExecStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -419,37 +425,39 @@ func TestLinux_StreamStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithMaxLogSize(10),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		if !test.container.Empty() {
-			_engine.steps.Store(test.container.ID, new(library.Step))
-			_engine.stepLogs.Store(test.container.ID, new(library.Log))
-		}
-
-		err = _engine.StreamStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("StreamStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithMaxLogSize(10),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			if !test.container.Empty() {
+				_engine.steps.Store(test.container.ID, new(library.Step))
+				_engine.stepLogs.Store(test.container.ID, new(library.Log))
+			}
 
-		if err != nil {
-			t.Errorf("StreamStep returned err: %v", err)
-		}
+			err = _engine.StreamStep(context.Background(), test.container)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("StreamStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("StreamStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -522,31 +530,33 @@ func TestLinux_DestroyStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-			WithVelaClient(_client),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.DestroyStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("DestroyStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+				WithVelaClient(_client),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.DestroyStep(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("DestroyStep returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("DestroyStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("DestroyStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -635,10 +645,12 @@ func TestLinux_getSecretValues(t *testing.T) {
 	}
 	// run tests
 	for _, test := range tests {
-		got := getSecretValues(test.container)
+		t.Run(test.name, func(t *testing.T) {
+			got := getSecretValues(test.container)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("getSecretValues is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("getSecretValues is %v, want %v", got, test.want)
+			}
+		})
 	}
 }

--- a/executor/linux/step_test.go
+++ b/executor/linux/step_test.go
@@ -45,10 +45,12 @@ func TestLinux_CreateStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // init step container
+		{
+			name:    "init step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -60,7 +62,8 @@ func TestLinux_CreateStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -72,7 +75,8 @@ func TestLinux_CreateStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // step container with image not found
+		{
+			name:    "step container with image not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -84,7 +88,8 @@ func TestLinux_CreateStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty step container
+		{
+			name:      "empty step container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -142,10 +147,12 @@ func TestLinux_PlanStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -157,7 +164,8 @@ func TestLinux_PlanStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // step container with nil environment
+		{
+			name:    "step container with nil environment",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -169,7 +177,8 @@ func TestLinux_PlanStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty step container
+		{
+			name:      "empty step container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -227,10 +236,12 @@ func TestLinux_ExecStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // init step container
+		{
+			name:    "init step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -242,7 +253,8 @@ func TestLinux_ExecStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -254,7 +266,8 @@ func TestLinux_ExecStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // detached step container
+		{
+			name:    "detached step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -267,7 +280,8 @@ func TestLinux_ExecStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // step container with image not found
+		{
+			name:    "step container with image not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -279,7 +293,8 @@ func TestLinux_ExecStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty step container
+		{
+			name:      "empty step container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -347,11 +362,13 @@ func TestLinux_StreamStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		logs      *library.Log
 		container *pipeline.Container
 	}{
-		{ // init step container
+		{
+			name:    "init step container",
 			failure: false,
 			logs:    _logs,
 			container: &pipeline.Container{
@@ -364,7 +381,8 @@ func TestLinux_StreamStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			logs:    _logs,
 			container: &pipeline.Container{
@@ -377,7 +395,8 @@ func TestLinux_StreamStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // step container with name not found
+		{
+			name:    "step container with name not found",
 			failure: true,
 			logs:    _logs,
 			container: &pipeline.Container{
@@ -390,7 +409,8 @@ func TestLinux_StreamStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty step container
+		{
+			name:      "empty step container",
 			failure:   true,
 			logs:      _logs,
 			container: new(pipeline.Container),
@@ -455,10 +475,12 @@ func TestLinux_DestroyStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // init step container
+		{
+			name:    "init step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -470,7 +492,8 @@ func TestLinux_DestroyStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -482,7 +505,8 @@ func TestLinux_DestroyStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // step container with ignoring name not found
+		{
+			name:    "step container with ignoring name not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_ignorenotfound",
@@ -533,10 +557,12 @@ func TestLinux_getSecretValues(t *testing.T) {
 	}
 
 	tests := []struct {
+		name      string
 		want      []string
 		container *pipeline.Container
 	}{
-		{ // no secrets container
+		{
+			name: "no secrets container",
 			want: []string{},
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -548,7 +574,8 @@ func TestLinux_getSecretValues(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // secrets container
+		{
+			name: "secrets container",
 			want: []string{"secretUser", "secretPass"},
 			container: &pipeline.Container{
 				ID:        "step_github_octocat_1_echo",
@@ -578,7 +605,8 @@ func TestLinux_getSecretValues(t *testing.T) {
 				},
 			},
 		},
-		{ // secrets container with file as value
+		{
+			name: "secrets container with file as value",
 			want: []string{"secretUser", "this is a secret"},
 			container: &pipeline.Container{
 				ID:        "step_github_octocat_1_ignorenotfound",

--- a/executor/local/api_test.go
+++ b/executor/local/api_test.go
@@ -40,23 +40,25 @@ func TestLocal_GetBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := test.engine.GetBuild()
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.engine.GetBuild()
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("GetBuild should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("GetBuild should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("GetBuild returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("GetBuild returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, _build) {
-			t.Errorf("GetBuild is %v, want %v", got, _build)
-		}
+			if !reflect.DeepEqual(got, _build) {
+				t.Errorf("GetBuild is %v, want %v", got, _build)
+			}
+		})
 	}
 }
 
@@ -91,23 +93,25 @@ func TestLocal_GetPipeline(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := test.engine.GetPipeline()
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.engine.GetPipeline()
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("GetPipeline should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("GetPipeline should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("GetPipeline returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("GetPipeline returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, _steps) {
-			t.Errorf("GetPipeline is %v, want %v", got, _steps)
-		}
+			if !reflect.DeepEqual(got, _steps) {
+				t.Errorf("GetPipeline is %v, want %v", got, _steps)
+			}
+		})
 	}
 }
 
@@ -142,22 +146,24 @@ func TestLocal_GetRepo(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := test.engine.GetRepo()
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.engine.GetRepo()
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("GetRepo should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("GetRepo should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("GetRepo returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("GetRepo returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, _repo) {
-			t.Errorf("GetRepo is %v, want %v", got, _repo)
-		}
+			if !reflect.DeepEqual(got, _repo) {
+				t.Errorf("GetRepo is %v, want %v", got, _repo)
+			}
+		})
 	}
 }

--- a/executor/local/api_test.go
+++ b/executor/local/api_test.go
@@ -22,14 +22,17 @@ func TestLocal_GetBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		engine  *client
 	}{
 		{
+			name:    "with build",
 			failure: false,
 			engine:  _engine,
 		},
 		{
+			name:    "missing build",
 			failure: true,
 			engine:  new(client),
 		},
@@ -70,14 +73,17 @@ func TestLocal_GetPipeline(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		engine  *client
 	}{
 		{
+			name:    "with pipeline",
 			failure: false,
 			engine:  _engine,
 		},
 		{
+			name:    "missing pipeline",
 			failure: true,
 			engine:  new(client),
 		},
@@ -118,14 +124,17 @@ func TestLocal_GetRepo(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		engine  *client
 	}{
 		{
+			name:    "with repo",
 			failure: false,
 			engine:  _engine,
 		},
 		{
+			name:    "missing repo",
 			failure: true,
 			engine:  new(client),
 		},

--- a/executor/local/build_test.go
+++ b/executor/local/build_test.go
@@ -29,18 +29,22 @@ func TestLocal_CreateBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
@@ -99,18 +103,22 @@ func TestLocal_PlanBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
@@ -175,42 +183,52 @@ func TestLocal_AssembleBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // services pipeline with image not found
+		{
+			name:     "services pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/services/img_notfound.yml",
 		},
-		{ // services pipeline with ignoring image not found
+		{
+			name:     "services pipeline with ignoring image not found",
 			failure:  true,
 			pipeline: "testdata/build/services/img_ignorenotfound.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // steps pipeline with image not found
+		{
+			name:     "steps pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/steps/img_notfound.yml",
 		},
-		{ // steps pipeline with ignoring image not found
+		{
+			name:     "steps pipeline with ignoring image not found",
 			failure:  true,
 			pipeline: "testdata/build/steps/img_ignorenotfound.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		{ // stages pipeline with image not found
+		{
+			name:     "stages pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/stages/img_notfound.yml",
 		},
-		{ // stages pipeline with ignoring image not found
+		{
+			name:     "stages pipeline with ignoring image not found",
 			failure:  true,
 			pipeline: "testdata/build/stages/img_ignorenotfound.yml",
 		},
@@ -275,30 +293,37 @@ func TestLocal_ExecBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // services pipeline with image not found
+		{
+			name:     "services pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/services/img_notfound.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // steps pipeline with image not found
+		{
+			name:     "steps pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/steps/img_notfound.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		{ // stages pipeline with image not found
+		{
+			name:     "stages pipeline with image not found",
 			failure:  true,
 			pipeline: "testdata/build/stages/img_notfound.yml",
 		},
@@ -363,30 +388,37 @@ func TestLocal_DestroyBuild(t *testing.T) {
 	}
 
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline string
 	}{
-		{ // basic services pipeline
+		{
+			name:     "basic services pipeline",
 			failure:  false,
 			pipeline: "testdata/build/services/basic.yml",
 		},
-		{ // services pipeline with name not found
+		{
+			name:     "services pipeline with name not found",
 			failure:  false,
 			pipeline: "testdata/build/services/name_notfound.yml",
 		},
-		{ // basic steps pipeline
+		{
+			name:     "basic steps pipeline",
 			failure:  false,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
-		{ // steps pipeline with name not found
+		{
+			name:     "steps pipeline with name not found",
 			failure:  false,
 			pipeline: "testdata/build/steps/name_notfound.yml",
 		},
-		{ // basic stages pipeline
+		{
+			name:     "basic stages pipeline",
 			failure:  false,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
-		{ // stages pipeline with name not found
+		{
+			name:     "stages pipeline with name not found",
 			failure:  false,
 			pipeline: "testdata/build/stages/name_notfound.yml",
 		},

--- a/executor/local/build_test.go
+++ b/executor/local/build_test.go
@@ -52,40 +52,42 @@ func TestLocal_CreateBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithLocal(true).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.CreateBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithLocal(true).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("CreateBuild returned err: %v", err)
-		}
+			err = _engine.CreateBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("CreateBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -126,46 +128,48 @@ func TestLocal_PlanBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithLocal(true).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		err = _engine.PlanBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("PlanBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithLocal(true).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("PlanBuild returned err: %v", err)
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
+
+			err = _engine.PlanBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("PlanBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("PlanBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -236,46 +240,48 @@ func TestLocal_AssembleBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithLocal(true).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		err = _engine.AssembleBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("AssembleBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithLocal(true).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("AssembleBuild returned err: %v", err)
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
+
+			err = _engine.AssembleBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("AssembleBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("AssembleBuild returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -331,46 +337,48 @@ func TestLocal_ExecBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithLocal(true).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		err = _engine.ExecBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("ExecBuild for %s should have returned err", test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithLocal(true).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("ExecBuild for %s returned err: %v", test.pipeline, err)
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
+
+			err = _engine.ExecBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("ExecBuild for %s should have returned err", test.pipeline)
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ExecBuild for %s returned err: %v", test.pipeline, err)
+			}
+		})
 	}
 }
 
@@ -426,45 +434,47 @@ func TestLocal_DestroyBuild(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		_pipeline, err := compiler.
-			WithBuild(_build).
-			WithRepo(_repo).
-			WithLocal(true).
-			WithUser(_user).
-			Compile(test.pipeline)
-		if err != nil {
-			t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
-		}
-
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		err = _engine.DestroyBuild(context.Background())
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("DestroyBuild should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_pipeline, err := compiler.
+				WithBuild(_build).
+				WithRepo(_repo).
+				WithLocal(true).
+				WithUser(_user).
+				Compile(test.pipeline)
+			if err != nil {
+				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
-			continue
-		}
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("DestroyBuild returned err: %v", err)
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
+
+			err = _engine.DestroyBuild(context.Background())
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("DestroyBuild should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("DestroyBuild returned err: %v", err)
+			}
+		})
 	}
 }

--- a/executor/local/local_test.go
+++ b/executor/local/local_test.go
@@ -56,27 +56,29 @@ func TestLocal_New(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err := New(
-			WithBuild(testBuild()),
-			WithHostname("localhost"),
-			WithPipeline(test.pipeline),
-			WithRepo(testRepo()),
-			WithRuntime(_runtime),
-			WithUser(testUser()),
-			WithVelaClient(_client),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_, err := New(
+				WithBuild(testBuild()),
+				WithHostname("localhost"),
+				WithPipeline(test.pipeline),
+				WithRepo(testRepo()),
+				WithRuntime(_runtime),
+				WithUser(testUser()),
+				WithVelaClient(_client),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("New should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("New should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("New returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("New returned err: %v", err)
+			}
+		})
 	}
 }
 

--- a/executor/local/local_test.go
+++ b/executor/local/local_test.go
@@ -38,14 +38,17 @@ func TestLocal_New(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps pipeline",
 			failure:  false,
 			pipeline: testSteps(),
 		},
 		{
+			name:     "nil pipeline",
 			failure:  true,
 			pipeline: nil,
 		},

--- a/executor/local/opts_test.go
+++ b/executor/local/opts_test.go
@@ -28,9 +28,11 @@ func TestLocal_Opt_WithBuild(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name  string
 		build *library.Build
 	}{
 		{
+			name:  "build",
 			build: _build,
 		},
 	}
@@ -54,14 +56,17 @@ func TestLocal_Opt_WithBuild(t *testing.T) {
 func TestLocal_Opt_WithHostname(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name     string
 		hostname string
 		want     string
 	}{
 		{
+			name:     "dns hostname",
 			hostname: "vela.worker.localhost",
 			want:     "vela.worker.localhost",
 		},
 		{
+			name:     "empty hostname is localhost",
 			hostname: "",
 			want:     "localhost",
 		},
@@ -88,14 +93,17 @@ func TestLocal_Opt_WithPipeline(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 	}{
 		{
+			name:     "steps pipeline",
 			failure:  false,
 			pipeline: _steps,
 		},
 		{
+			name:     "nil pipeline",
 			failure:  true,
 			pipeline: nil,
 		},
@@ -131,9 +139,11 @@ func TestLocal_Opt_WithRepo(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name string
 		repo *library.Repo
 	}{
 		{
+			name: "repo",
 			repo: _repo,
 		},
 	}
@@ -163,14 +173,17 @@ func TestLocal_Opt_WithRuntime(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		runtime runtime.Engine
 	}{
 		{
+			name:    "docker runtime",
 			failure: false,
 			runtime: _runtime,
 		},
 		{
+			name:    "nil runtime",
 			failure: true,
 			runtime: nil,
 		},
@@ -206,9 +219,11 @@ func TestLocal_Opt_WithUser(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name string
 		user *library.User
 	}{
 		{
+			name: "user",
 			user: _user,
 		},
 	}
@@ -242,9 +257,11 @@ func TestLocal_Opt_WithVelaClient(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name   string
 		client *vela.Client
 	}{
 		{
+			name:   "vela client",
 			client: _client,
 		},
 	}
@@ -268,14 +285,17 @@ func TestLocal_Opt_WithVelaClient(t *testing.T) {
 func TestLocal_Opt_WithVersion(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		version string
 		want    string
 	}{
 		{
+			name:    "version",
 			version: "v1.0.0",
 			want:    "v1.0.0",
 		},
 		{
+			name:    "empty version",
 			version: "",
 			want:    "v0.0.0",
 		},

--- a/executor/local/opts_test.go
+++ b/executor/local/opts_test.go
@@ -39,17 +39,19 @@ func TestLocal_Opt_WithBuild(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(test.build),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(test.build),
+			)
 
-		if err != nil {
-			t.Errorf("WithBuild returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WithBuild returned err: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.build, _build) {
-			t.Errorf("WithBuild is %v, want %v", _engine.build, _build)
-		}
+			if !reflect.DeepEqual(_engine.build, _build) {
+				t.Errorf("WithBuild is %v, want %v", _engine.build, _build)
+			}
+		})
 	}
 }
 
@@ -74,16 +76,18 @@ func TestLocal_Opt_WithHostname(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithHostname(test.hostname),
-		)
-		if err != nil {
-			t.Errorf("unable to create local engine: %v", err)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithHostname(test.hostname),
+			)
+			if err != nil {
+				t.Errorf("unable to create local engine: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.Hostname, test.want) {
-			t.Errorf("WithHostname is %v, want %v", _engine.Hostname, test.want)
-		}
+			if !reflect.DeepEqual(_engine.Hostname, test.want) {
+				t.Errorf("WithHostname is %v, want %v", _engine.Hostname, test.want)
+			}
+		})
 	}
 }
 
@@ -111,25 +115,27 @@ func TestLocal_Opt_WithPipeline(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithPipeline(test.pipeline),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithPipeline(test.pipeline),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithPipeline should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithPipeline should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithPipeline returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithPipeline returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.pipeline, _steps) {
-			t.Errorf("WithPipeline is %v, want %v", _engine.pipeline, _steps)
-		}
+			if !reflect.DeepEqual(_engine.pipeline, _steps) {
+				t.Errorf("WithPipeline is %v, want %v", _engine.pipeline, _steps)
+			}
+		})
 	}
 }
 
@@ -150,17 +156,19 @@ func TestLocal_Opt_WithRepo(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithRepo(test.repo),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithRepo(test.repo),
+			)
 
-		if err != nil {
-			t.Errorf("WithRepo returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WithRepo returned err: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.repo, _repo) {
-			t.Errorf("WithRepo is %v, want %v", _engine.repo, _repo)
-		}
+			if !reflect.DeepEqual(_engine.repo, _repo) {
+				t.Errorf("WithRepo is %v, want %v", _engine.repo, _repo)
+			}
+		})
 	}
 }
 
@@ -191,25 +199,27 @@ func TestLocal_Opt_WithRuntime(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithRuntime(test.runtime),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithRuntime(test.runtime),
+			)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("WithRuntime should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("WithRuntime should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("WithRuntime returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("WithRuntime returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(_engine.Runtime, _runtime) {
-			t.Errorf("WithRuntime is %v, want %v", _engine.Runtime, _runtime)
-		}
+			if !reflect.DeepEqual(_engine.Runtime, _runtime) {
+				t.Errorf("WithRuntime is %v, want %v", _engine.Runtime, _runtime)
+			}
+		})
 	}
 }
 
@@ -230,17 +240,19 @@ func TestLocal_Opt_WithUser(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithUser(test.user),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithUser(test.user),
+			)
 
-		if err != nil {
-			t.Errorf("WithUser returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WithUser returned err: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.user, _user) {
-			t.Errorf("WithUser is %v, want %v", _engine.user, _user)
-		}
+			if !reflect.DeepEqual(_engine.user, _user) {
+				t.Errorf("WithUser is %v, want %v", _engine.user, _user)
+			}
+		})
 	}
 }
 
@@ -268,17 +280,19 @@ func TestLocal_Opt_WithVelaClient(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithVelaClient(test.client),
-		)
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithVelaClient(test.client),
+			)
 
-		if err != nil {
-			t.Errorf("WithVelaClient returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("WithVelaClient returned err: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.Vela, _client) {
-			t.Errorf("WithVelaClient is %v, want %v", _engine.Vela, _client)
-		}
+			if !reflect.DeepEqual(_engine.Vela, _client) {
+				t.Errorf("WithVelaClient is %v, want %v", _engine.Vela, _client)
+			}
+		})
 	}
 }
 
@@ -303,15 +317,17 @@ func TestLocal_Opt_WithVersion(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithVersion(test.version),
-		)
-		if err != nil {
-			t.Errorf("unable to create local engine: %v", err)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithVersion(test.version),
+			)
+			if err != nil {
+				t.Errorf("unable to create local engine: %v", err)
+			}
 
-		if !reflect.DeepEqual(_engine.Version, test.want) {
-			t.Errorf("WithVersion is %v, want %v", _engine.Version, test.want)
-		}
+			if !reflect.DeepEqual(_engine.Version, test.want) {
+				t.Errorf("WithVersion is %v, want %v", _engine.Version, test.want)
+			}
+		})
 	}
 }

--- a/executor/local/service_test.go
+++ b/executor/local/service_test.go
@@ -27,10 +27,12 @@ func TestLocal_CreateService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -44,7 +46,8 @@ func TestLocal_CreateService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // service container with image not found
+		{
+			name:    "service container with image not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -58,7 +61,8 @@ func TestLocal_CreateService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty service container
+		{
+			name:      "empty service container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -106,10 +110,12 @@ func TestLocal_PlanService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -123,7 +129,8 @@ func TestLocal_PlanService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty service container
+		{
+			name:      "empty service container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -171,10 +178,12 @@ func TestLocal_ExecService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -188,7 +197,8 @@ func TestLocal_ExecService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // service container with image not found
+		{
+			name:    "service container with image not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -202,7 +212,8 @@ func TestLocal_ExecService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty service container
+		{
+			name:      "empty service container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -254,10 +265,12 @@ func TestLocal_StreamService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
@@ -271,7 +284,8 @@ func TestLocal_StreamService(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty service container
+		{
+			name:      "empty service container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -319,10 +333,12 @@ func TestLocal_DestroyService(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic service container
+		{
+			name:    "basic service container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",

--- a/executor/local/service_test.go
+++ b/executor/local/service_test.go
@@ -70,30 +70,32 @@ func TestLocal_CreateService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.CreateService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.CreateService(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("CreateService returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("CreateService returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -138,30 +140,32 @@ func TestLocal_PlanService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.PlanService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("PlanService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.PlanService(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("PlanService returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("PlanService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("PlanService returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -221,34 +225,36 @@ func TestLocal_ExecService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		if !test.container.Empty() {
-			_engine.services.Store(test.container.ID, new(library.Service))
-		}
-
-		err = _engine.ExecService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("ExecService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			if !test.container.Empty() {
+				_engine.services.Store(test.container.ID, new(library.Service))
+			}
 
-		if err != nil {
-			t.Errorf("ExecService returned err: %v", err)
-		}
+			err = _engine.ExecService(context.Background(), test.container)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("ExecService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ExecService returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -293,30 +299,32 @@ func TestLocal_StreamService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.StreamService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("StreamService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.StreamService(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("StreamService returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("StreamService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("StreamService returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -356,29 +364,31 @@ func TestLocal_DestroyService(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.DestroyService(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("DestroyService should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.DestroyService(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("DestroyService returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("DestroyService should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("DestroyService returned err: %v", err)
+			}
+		})
 	}
 }

--- a/executor/local/stage_test.go
+++ b/executor/local/stage_test.go
@@ -46,10 +46,12 @@ func TestLocal_CreateStage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		stage   *pipeline.Stage
 	}{
-		{ // basic stage
+		{
+			name:    "basic stage",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -66,7 +68,8 @@ func TestLocal_CreateStage(t *testing.T) {
 				},
 			},
 		},
-		{ // stage with step container with image not found
+		{
+			name:    "stage with step container with image not found",
 			failure: true,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -147,11 +150,13 @@ func TestLocal_PlanStage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		stage    *pipeline.Stage
 		stageMap *sync.Map
 	}{
-		{ // basic stage
+		{
+			name:    "basic stage",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -169,7 +174,8 @@ func TestLocal_PlanStage(t *testing.T) {
 			},
 			stageMap: new(sync.Map),
 		},
-		{ // basic stage with nil stage map
+		{
+			name:    "basic stage with nil stage map",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name:  "echo",
@@ -188,7 +194,8 @@ func TestLocal_PlanStage(t *testing.T) {
 			},
 			stageMap: testMap,
 		},
-		{ // basic stage with error stage map
+		{
+			name:    "basic stage with error stage map",
 			failure: true,
 			stage: &pipeline.Stage{
 				Name:  "echo",
@@ -251,10 +258,12 @@ func TestLocal_ExecStage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		stage   *pipeline.Stage
 	}{
-		{ // basic stage
+		{
+			name:    "basic stage",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -271,7 +280,8 @@ func TestLocal_ExecStage(t *testing.T) {
 				},
 			},
 		},
-		{ // stage with step container with image not found
+		{
+			name:    "stage with step container with image not found",
 			failure: true,
 			stage: &pipeline.Stage{
 				Name: "echo",
@@ -335,10 +345,12 @@ func TestLocal_DestroyStage(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		stage   *pipeline.Stage
 	}{
-		{ // basic stage
+		{
+			name:    "basic stage",
 			failure: false,
 			stage: &pipeline.Stage{
 				Name: "echo",

--- a/executor/local/stage_test.go
+++ b/executor/local/stage_test.go
@@ -90,36 +90,38 @@ func TestLocal_CreateStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(_pipeline),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		// run create to init steps to be created properly
-		err = _engine.CreateBuild(context.Background())
-		if err != nil {
-			t.Errorf("unable to create build: %v", err)
-		}
-
-		err = _engine.CreateStage(context.Background(), test.stage)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateStage should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(_pipeline),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			// run create to init steps to be created properly
+			err = _engine.CreateBuild(context.Background())
+			if err != nil {
+				t.Errorf("unable to create build: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("CreateStage returned err: %v", err)
-		}
+			err = _engine.CreateStage(context.Background(), test.stage)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateStage should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("CreateStage returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -218,30 +220,32 @@ func TestLocal_PlanStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.PlanStage(context.Background(), test.stage, test.stageMap)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("PlanStage should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.PlanStage(context.Background(), test.stage, test.stageMap)
 
-		if err != nil {
-			t.Errorf("PlanStage returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("PlanStage should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("PlanStage returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -302,33 +306,35 @@ func TestLocal_ExecStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		stageMap := new(sync.Map)
-		stageMap.Store("echo", make(chan error))
+		t.Run(test.name, func(t *testing.T) {
+			stageMap := new(sync.Map)
+			stageMap.Store("echo", make(chan error))
 
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.ExecStage(context.Background(), test.stage, stageMap)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("ExecStage should have returned err")
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.ExecStage(context.Background(), test.stage, stageMap)
 
-		if err != nil {
-			t.Errorf("ExecStage returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("ExecStage should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ExecStage returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -371,29 +377,31 @@ func TestLocal_DestroyStage(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.DestroyStage(context.Background(), test.stage)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("DestroyStage should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.DestroyStage(context.Background(), test.stage)
 
-		if err != nil {
-			t.Errorf("DestroyStage returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("DestroyStage should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("DestroyStage returned err: %v", err)
+			}
+		})
 	}
 }

--- a/executor/local/step_test.go
+++ b/executor/local/step_test.go
@@ -79,30 +79,32 @@ func TestLocal_CreateStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.CreateStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("CreateStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.CreateStep(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("CreateStep returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("CreateStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("CreateStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -145,30 +147,32 @@ func TestLocal_PlanStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.PlanStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("PlanStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.PlanStep(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("PlanStep returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("PlanStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("PlanStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -251,34 +255,36 @@ func TestLocal_ExecStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		if !test.container.Empty() {
-			_engine.steps.Store(test.container.ID, new(library.Step))
-		}
-
-		err = _engine.ExecStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("ExecStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			if !test.container.Empty() {
+				_engine.steps.Store(test.container.ID, new(library.Step))
+			}
 
-		if err != nil {
-			t.Errorf("ExecStep returned err: %v", err)
-		}
+			err = _engine.ExecStep(context.Background(), test.container)
+
+			if test.failure {
+				if err == nil {
+					t.Errorf("ExecStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ExecStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -347,30 +353,32 @@ func TestLocal_StreamStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.StreamStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("StreamStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.StreamStep(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("StreamStep returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("StreamStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("StreamStep returned err: %v", err)
+			}
+		})
 	}
 }
 
@@ -421,29 +429,31 @@ func TestLocal_DestroyStep(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine, err := New(
-			WithBuild(_build),
-			WithPipeline(new(pipeline.Build)),
-			WithRepo(_repo),
-			WithRuntime(_runtime),
-			WithUser(_user),
-		)
-		if err != nil {
-			t.Errorf("unable to create executor engine: %v", err)
-		}
-
-		err = _engine.DestroyStep(context.Background(), test.container)
-
-		if test.failure {
-			if err == nil {
-				t.Errorf("DestroyStep should have returned err")
+		t.Run(test.name, func(t *testing.T) {
+			_engine, err := New(
+				WithBuild(_build),
+				WithPipeline(new(pipeline.Build)),
+				WithRepo(_repo),
+				WithRuntime(_runtime),
+				WithUser(_user),
+			)
+			if err != nil {
+				t.Errorf("unable to create executor engine: %v", err)
 			}
 
-			continue
-		}
+			err = _engine.DestroyStep(context.Background(), test.container)
 
-		if err != nil {
-			t.Errorf("DestroyStep returned err: %v", err)
-		}
+			if test.failure {
+				if err == nil {
+					t.Errorf("DestroyStep should have returned err")
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("DestroyStep returned err: %v", err)
+			}
+		})
 	}
 }

--- a/executor/local/step_test.go
+++ b/executor/local/step_test.go
@@ -27,10 +27,12 @@ func TestLocal_CreateStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // init step container
+		{
+			name:    "init step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -42,7 +44,8 @@ func TestLocal_CreateStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -54,7 +57,8 @@ func TestLocal_CreateStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // step container with image not found
+		{
+			name:    "step container with image not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -66,7 +70,8 @@ func TestLocal_CreateStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty step container
+		{
+			name:      "empty step container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -114,10 +119,12 @@ func TestLocal_PlanStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -129,7 +136,8 @@ func TestLocal_PlanStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty step container
+		{
+			name:      "empty step container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -177,10 +185,12 @@ func TestLocal_ExecStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // init step container
+		{
+			name:    "init step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -192,7 +202,8 @@ func TestLocal_ExecStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -204,7 +215,8 @@ func TestLocal_ExecStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // detached step container
+		{
+			name:    "detached step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -217,7 +229,8 @@ func TestLocal_ExecStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // step container with image not found
+		{
+			name:    "step container with image not found",
 			failure: true,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -229,7 +242,8 @@ func TestLocal_ExecStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty step container
+		{
+			name:      "empty step container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -281,10 +295,12 @@ func TestLocal_StreamStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // init step container
+		{
+			name:    "init step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -296,7 +312,8 @@ func TestLocal_StreamStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -308,7 +325,8 @@ func TestLocal_StreamStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic stage container
+		{
+			name:    "basic stage container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "github_octocat_1_echo_echo",
@@ -320,7 +338,8 @@ func TestLocal_StreamStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // empty step container
+		{
+			name:      "empty step container",
 			failure:   true,
 			container: new(pipeline.Container),
 		},
@@ -368,10 +387,12 @@ func TestLocal_DestroyStep(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 	}{
-		{ // init step container
+		{
+			name:    "init step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -383,7 +404,8 @@ func TestLocal_DestroyStep(t *testing.T) {
 				Pull:        "not_present",
 			},
 		},
-		{ // basic step container
+		{
+			name:    "basic step container",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",

--- a/executor/setup_test.go
+++ b/executor/setup_test.go
@@ -381,18 +381,20 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err = test.setup.Validate()
+		t.Run(test.name, func(t *testing.T) {
+			err = test.setup.Validate()
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("Validate should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("Validate should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("Validate returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("Validate returned err: %v", err)
+			}
+		})
 	}
 }

--- a/executor/setup_test.go
+++ b/executor/setup_test.go
@@ -223,10 +223,12 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name    string
 		setup   *Setup
 		failure bool
 	}{
 		{
+			name: "complete",
 			setup: &Setup{
 				Build:      _build,
 				Client:     _client,
@@ -241,6 +243,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: false,
 		},
 		{
+			name: "nil build",
 			setup: &Setup{
 				Build:      nil,
 				Client:     _client,
@@ -255,6 +258,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: true,
 		},
 		{
+			name: "nil client",
 			setup: &Setup{
 				Build:      _build,
 				Client:     nil,
@@ -269,6 +273,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: true,
 		},
 		{
+			name: "empty driver",
 			setup: &Setup{
 				Build:      _build,
 				Client:     _client,
@@ -283,6 +288,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: true,
 		},
 		{
+			name: "nil pipeline",
 			setup: &Setup{
 				Build:      _build,
 				Client:     _client,
@@ -297,6 +303,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: true,
 		},
 		{
+			name: "nil repo",
 			setup: &Setup{
 				Build:      _build,
 				Client:     _client,
@@ -311,6 +318,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: true,
 		},
 		{
+			name: "nil runtime",
 			setup: &Setup{
 				Build:      _build,
 				Client:     _client,
@@ -325,6 +333,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: true,
 		},
 		{
+			name: "nil user",
 			setup: &Setup{
 				Build:      _build,
 				Client:     _client,
@@ -339,6 +348,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: true,
 		},
 		{
+			name: "empty log-method",
 			setup: &Setup{
 				Build:      _build,
 				Client:     _client,
@@ -353,6 +363,7 @@ func TestExecutor_Setup_Validate(t *testing.T) {
 			failure: true,
 		},
 		{
+			name: "invalid log-method",
 			setup: &Setup{
 				Build:      _build,
 				Client:     _client,


### PR DESCRIPTION
I use Goland to run `go test`. At least with Goland, `testing.Run()` improves the output and test selection. And it makes it easier to see which subtest has failed.

As I develop and refactor, I would really like to see this everywhere. This updates all tests under `executor/` as #312 did for `runtime/`.
