### PR TITLE
tests: Convert internal/ tests to subtests

### DIFF
--- a/internal/build/snapshot_test.go
+++ b/internal/build/snapshot_test.go
@@ -73,24 +73,28 @@ func TestBuild_Snapshot(t *testing.T) {
 	}
 
 	tests := []struct {
+		name   string
 		build  *library.Build
 		client *vela.Client
 		err    error
 		repo   *library.Repo
 	}{
 		{
+			name:   "build with error",
 			build:  b,
 			client: _client,
 			err:    errors.New("unable to create network"),
 			repo:   r,
 		},
 		{
+			name:   "nil build with error",
 			build:  nil,
 			client: _client,
 			err:    errors.New("unable to create network"),
 			repo:   r,
 		},
 		{
+			name:   "nil everything",
 			build:  nil,
 			client: nil,
 			err:    nil,

--- a/internal/build/snapshot_test.go
+++ b/internal/build/snapshot_test.go
@@ -104,6 +104,8 @@ func TestBuild_Snapshot(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		Snapshot(test.build, test.client, test.err, nil, test.repo)
+		t.Run(test.name, func(t *testing.T) {
+			Snapshot(test.build, test.client, test.err, nil, test.repo)
+		})
 	}
 }

--- a/internal/build/upload_test.go
+++ b/internal/build/upload_test.go
@@ -134,6 +134,8 @@ func TestBuild_Upload(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		Upload(test.build, test.client, test.err, nil, test.repo)
+		t.Run(test.name, func(t *testing.T) {
+			Upload(test.build, test.client, test.err, nil, test.repo)
+		})
 	}
 }

--- a/internal/build/upload_test.go
+++ b/internal/build/upload_test.go
@@ -82,42 +82,49 @@ func TestBuild_Upload(t *testing.T) {
 	}
 
 	tests := []struct {
+		name   string
 		build  *library.Build
 		client *vela.Client
 		err    error
 		repo   *library.Repo
 	}{
 		{
+			name:   "build with error",
 			build:  _build,
 			client: _client,
 			err:    errors.New("unable to create network"),
 			repo:   _repo,
 		},
 		{
+			name:   "canceled build with error",
 			build:  &_canceled,
 			client: _client,
 			err:    errors.New("unable to create network"),
 			repo:   _repo,
 		},
 		{
+			name:   "errored build with error",
 			build:  &_error,
 			client: _client,
 			err:    errors.New("unable to create network"),
 			repo:   _repo,
 		},
 		{
+			name:   "pending build with error",
 			build:  &_pending,
 			client: _client,
 			err:    errors.New("unable to create network"),
 			repo:   _repo,
 		},
 		{
+			name:   "nil build with error",
 			build:  nil,
 			client: _client,
 			err:    errors.New("unable to create network"),
 			repo:   _repo,
 		},
 		{
+			name:   "everything nil",
 			build:  nil,
 			client: nil,
 			err:    nil,

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -75,11 +75,13 @@ func TestImage_Parse(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := Parse(test.image)
+		t.Run(test.name, func(t *testing.T) {
+			got := Parse(test.image)
 
-		if !strings.EqualFold(got, test.want) {
-			t.Errorf("Parse is %s want %s", got, test.want)
-		}
+			if !strings.EqualFold(got, test.want) {
+				t.Errorf("Parse is %s want %s", got, test.want)
+			}
+		})
 	}
 }
 
@@ -125,27 +127,29 @@ func TestImage_ParseWithError(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := ParseWithError(test.image)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseWithError(test.image)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("ParseWithError should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("ParseWithError should have returned err")
+				}
+
+				if !strings.EqualFold(got, test.want) {
+					t.Errorf("ParseWithError is %s want %s", got, test.want)
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ParseWithError returned err: %v", err)
 			}
 
 			if !strings.EqualFold(got, test.want) {
 				t.Errorf("ParseWithError is %s want %s", got, test.want)
 			}
-
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("ParseWithError returned err: %v", err)
-		}
-
-		if !strings.EqualFold(got, test.want) {
-			t.Errorf("ParseWithError is %s want %s", got, test.want)
-		}
+		})
 	}
 }
 

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -12,50 +12,62 @@ import (
 func TestImage_Parse(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name  string
 		image string
 		want  string
 	}{
 		{
+			name:  "image only",
 			image: "golang",
 			want:  "docker.io/library/golang:latest",
 		},
 		{
+			name:  "image and tag",
 			image: "golang:latest",
 			want:  "docker.io/library/golang:latest",
 		},
 		{
+			name:  "repo and image",
 			image: "library/golang",
 			want:  "docker.io/library/golang:latest",
 		},
 		{
+			name:  "repo image and tag",
 			image: "library/golang:1.14",
 			want:  "docker.io/library/golang:1.14",
 		},
 		{
+			name:  "hub repo and image",
 			image: "docker.io/library/golang",
 			want:  "docker.io/library/golang:latest",
 		},
 		{
+			name:  "hub repo image and tag",
 			image: "docker.io/library/golang:latest",
 			want:  "docker.io/library/golang:latest",
 		},
 		{
+			name:  "alt hub with repo and image",
 			image: "index.docker.io/library/golang",
 			want:  "docker.io/library/golang:latest",
 		},
 		{
+			name:  "alt hub with repo image and tag",
 			image: "index.docker.io/library/golang:latest",
 			want:  "docker.io/library/golang:latest",
 		},
 		{
+			name:  "gcr hub with repo and image",
 			image: "gcr.io/library/golang",
 			want:  "gcr.io/library/golang:latest",
 		},
 		{
+			name:  "gcr hub with repo image and tag",
 			image: "gcr.io/library/golang:latest",
 			want:  "gcr.io/library/golang:latest",
 		},
 		{
+			name:  "garbage in garbage out",
 			image: "!@#$%^&*()",
 			want:  "!@#$%^&*()",
 		},
@@ -74,31 +86,37 @@ func TestImage_Parse(t *testing.T) {
 func TestImage_ParseWithError(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		image   string
 		want    string
 	}{
 		{
+			name:    "image only",
 			failure: false,
 			image:   "golang",
 			want:    "docker.io/library/golang:latest",
 		},
 		{
+			name:    "image and tag",
 			failure: false,
 			image:   "golang:latest",
 			want:    "docker.io/library/golang:latest",
 		},
 		{
+			name:    "image and tag",
 			failure: false,
 			image:   "golang:1.14",
 			want:    "docker.io/library/golang:1.14",
 		},
 		{
+			name:    "fails with bad image",
 			failure: true,
 			image:   "!@#$%^&*()",
 			want:    "!@#$%^&*()",
 		},
 		{
+			name:    "fails with image sha",
 			failure: true,
 			image:   "1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
 			want:    "sha256:1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",

--- a/internal/service/environment_test.go
+++ b/internal/service/environment_test.go
@@ -93,6 +93,7 @@ func TestService_Environment(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		build     *library.Build
 		container *pipeline.Container
@@ -100,6 +101,7 @@ func TestService_Environment(t *testing.T) {
 		service   *library.Service
 	}{
 		{
+			name:      "success",
 			failure:   false,
 			build:     b,
 			container: c,
@@ -107,6 +109,7 @@ func TestService_Environment(t *testing.T) {
 			service:   s,
 		},
 		{
+			name:      "nil failure",
 			failure:   true,
 			build:     nil,
 			container: nil,

--- a/internal/service/environment_test.go
+++ b/internal/service/environment_test.go
@@ -120,18 +120,20 @@ func TestService_Environment(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := Environment(test.container, test.build, test.repo, test.service, "v0.0.0")
+		t.Run(test.name, func(t *testing.T) {
+			err := Environment(test.container, test.build, test.repo, test.service, "v0.0.0")
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("Environment should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("Environment should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("Environment returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("Environment returned err: %v", err)
+			}
+		})
 	}
 }

--- a/internal/service/load_test.go
+++ b/internal/service/load_test.go
@@ -72,23 +72,25 @@ func TestService_Load(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := Load(test.container, test._map)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Load(test.container, test._map)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("Load should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("Load should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("Load returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("Load returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("Load is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("Load is %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 
@@ -151,22 +153,24 @@ func TestStep_LoadLogs(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := LoadLogs(test.container, test._map)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := LoadLogs(test.container, test._map)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("LoadLogs should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("LoadLogs should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("LoadLogs returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("LoadLogs returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("LoadLogs is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("LoadLogs is %v, want %v", got, test.want)
+			}
+		})
 	}
 }

--- a/internal/service/load_test.go
+++ b/internal/service/load_test.go
@@ -34,30 +34,35 @@ func TestService_Load(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 		_map      *sync.Map
 		want      *library.Service
 	}{
 		{
+			name:      "good map",
 			failure:   false,
 			container: c,
 			want:      new(library.Service),
 			_map:      goodMap,
 		},
 		{
+			name:      "bad map",
 			failure:   true,
 			container: c,
 			want:      nil,
 			_map:      badMap,
 		},
 		{
+			name:      "empty map",
 			failure:   true,
 			container: new(pipeline.Container),
 			want:      nil,
 			_map:      new(sync.Map),
 		},
 		{
+			name:      "nil map",
 			failure:   true,
 			container: nil,
 			want:      nil,
@@ -108,30 +113,35 @@ func TestStep_LoadLogs(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 		_map      *sync.Map
 		want      *library.Log
 	}{
 		{
+			name:      "good map",
 			failure:   false,
 			container: c,
 			want:      new(library.Log),
 			_map:      goodMap,
 		},
 		{
+			name:      "bad map",
 			failure:   true,
 			container: c,
 			want:      nil,
 			_map:      badMap,
 		},
 		{
+			name:      "empty map",
 			failure:   true,
 			container: new(pipeline.Container),
 			want:      nil,
 			_map:      new(sync.Map),
 		},
 		{
+			name:      "nil map",
 			failure:   true,
 			container: nil,
 			want:      nil,

--- a/internal/service/snapshot_test.go
+++ b/internal/service/snapshot_test.go
@@ -113,6 +113,7 @@ func TestService_Snapshot(t *testing.T) {
 	}
 
 	tests := []struct {
+		name      string
 		build     *library.Build
 		client    *vela.Client
 		container *pipeline.Container
@@ -120,6 +121,7 @@ func TestService_Snapshot(t *testing.T) {
 		service   *library.Service
 	}{
 		{
+			name:      "running service",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -127,6 +129,7 @@ func TestService_Snapshot(t *testing.T) {
 			service:   _service,
 		},
 		{
+			name:      "exited service",
 			build:     _build,
 			client:    _client,
 			container: _exitCode,

--- a/internal/service/snapshot_test.go
+++ b/internal/service/snapshot_test.go
@@ -140,6 +140,8 @@ func TestService_Snapshot(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		Snapshot(test.container, test.build, test.client, nil, test.repo, test.service)
+		t.Run(test.name, func(t *testing.T) {
+			Snapshot(test.container, test.build, test.client, nil, test.repo, test.service)
+		})
 	}
 }

--- a/internal/service/upload_test.go
+++ b/internal/service/upload_test.go
@@ -171,6 +171,8 @@ func TestService_Upload(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		Upload(test.container, test.build, test.client, nil, test.repo, test.service)
+		t.Run(test.name, func(t *testing.T) {
+			Upload(test.container, test.build, test.client, nil, test.repo, test.service)
+		})
 	}
 }

--- a/internal/service/upload_test.go
+++ b/internal/service/upload_test.go
@@ -120,6 +120,7 @@ func TestService_Upload(t *testing.T) {
 	}
 
 	tests := []struct {
+		name      string
 		build     *library.Build
 		client    *vela.Client
 		container *pipeline.Container
@@ -127,6 +128,7 @@ func TestService_Upload(t *testing.T) {
 		service   *library.Service
 	}{
 		{
+			name:      "running service",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -134,6 +136,7 @@ func TestService_Upload(t *testing.T) {
 			service:   _service,
 		},
 		{
+			name:      "canceled service",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -141,6 +144,7 @@ func TestService_Upload(t *testing.T) {
 			service:   &_canceled,
 		},
 		{
+			name:      "errored service",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -148,6 +152,7 @@ func TestService_Upload(t *testing.T) {
 			service:   &_error,
 		},
 		{
+			name:      "pending service",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -155,6 +160,7 @@ func TestService_Upload(t *testing.T) {
 			service:   &_pending,
 		},
 		{
+			name:      "exited service",
 			build:     _build,
 			client:    _client,
 			container: _exitCode,

--- a/internal/step/environment_test.go
+++ b/internal/step/environment_test.go
@@ -92,6 +92,7 @@ func TestStep_Environment(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		build     *library.Build
 		container *pipeline.Container
@@ -99,6 +100,7 @@ func TestStep_Environment(t *testing.T) {
 		step      *library.Step
 	}{
 		{
+			name:      "success",
 			failure:   false,
 			build:     b,
 			container: c,
@@ -106,6 +108,7 @@ func TestStep_Environment(t *testing.T) {
 			step:      s,
 		},
 		{
+			name:      "nil failure",
 			failure:   true,
 			build:     nil,
 			container: nil,

--- a/internal/step/environment_test.go
+++ b/internal/step/environment_test.go
@@ -119,18 +119,20 @@ func TestStep_Environment(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		err := Environment(test.container, test.build, test.repo, test.step, "v0.0.0")
+		t.Run(test.name, func(t *testing.T) {
+			err := Environment(test.container, test.build, test.repo, test.step, "v0.0.0")
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("Environment should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("Environment should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("Environment returned err: %v", err)
-		}
+			if err != nil {
+				t.Errorf("Environment returned err: %v", err)
+			}
+		})
 	}
 }

--- a/internal/step/load_test.go
+++ b/internal/step/load_test.go
@@ -71,23 +71,25 @@ func TestStep_Load(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := Load(test.container, test._map)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Load(test.container, test._map)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("Load should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("Load should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("Load returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("Load returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("Load is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("Load is %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 
@@ -170,23 +172,25 @@ func TestStep_LoadInit(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := LoadInit(test.pipeline)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := LoadInit(test.pipeline)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("LoadInit should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("LoadInit should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("LoadInit returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("LoadInit returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("LoadInit is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("LoadInit is %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 
@@ -248,22 +252,24 @@ func TestStep_LoadLogs(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := LoadLogs(test.container, test._map)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := LoadLogs(test.container, test._map)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("LoadLogs should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("LoadLogs should have returned err")
+				}
+
+				return // continue to next test
 			}
 
-			continue
-		}
+			if err != nil {
+				t.Errorf("LoadLogs returned err: %v", err)
+			}
 
-		if err != nil {
-			t.Errorf("LoadLogs returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("LoadLogs is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("LoadLogs is %v, want %v", got, test.want)
+			}
+		})
 	}
 }

--- a/internal/step/load_test.go
+++ b/internal/step/load_test.go
@@ -33,30 +33,35 @@ func TestStep_Load(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 		_map      *sync.Map
 		want      *library.Step
 	}{
 		{
+			name:      "good map",
 			failure:   false,
 			container: c,
 			want:      new(library.Step),
 			_map:      goodMap,
 		},
 		{
+			name:      "bad map",
 			failure:   true,
 			container: c,
 			want:      nil,
 			_map:      badMap,
 		},
 		{
+			name:      "empty map",
 			failure:   true,
 			container: new(pipeline.Container),
 			want:      nil,
 			_map:      new(sync.Map),
 		},
 		{
+			name:      "nil map",
 			failure:   true,
 			container: nil,
 			want:      nil,
@@ -89,11 +94,13 @@ func TestStep_Load(t *testing.T) {
 func TestStep_LoadInit(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name     string
 		failure  bool
 		pipeline *pipeline.Build
 		want     *pipeline.Container
 	}{
 		{
+			name:    "stages",
 			failure: false,
 			pipeline: &pipeline.Build{
 				Version: "1",
@@ -126,6 +133,7 @@ func TestStep_LoadInit(t *testing.T) {
 			},
 		},
 		{
+			name:    "steps",
 			failure: false,
 			pipeline: &pipeline.Build{
 				Version: "1",
@@ -153,6 +161,7 @@ func TestStep_LoadInit(t *testing.T) {
 			},
 		},
 		{
+			name:     "nil failure",
 			failure:  true,
 			pipeline: nil,
 			want:     nil,
@@ -201,30 +210,35 @@ func TestStep_LoadLogs(t *testing.T) {
 
 	// setup tests
 	tests := []struct {
+		name      string
 		failure   bool
 		container *pipeline.Container
 		_map      *sync.Map
 		want      *library.Log
 	}{
 		{
+			name:      "good map",
 			failure:   false,
 			container: c,
 			want:      new(library.Log),
 			_map:      goodMap,
 		},
 		{
+			name:      "bad map",
 			failure:   true,
 			container: c,
 			want:      nil,
 			_map:      badMap,
 		},
 		{
+			name:      "empty map",
 			failure:   true,
 			container: new(pipeline.Container),
 			want:      nil,
 			_map:      new(sync.Map),
 		},
 		{
+			name:      "nil map",
 			failure:   true,
 			container: nil,
 			want:      nil,

--- a/internal/step/skip_test.go
+++ b/internal/step/skip_test.go
@@ -152,36 +152,42 @@ func TestStep_Skip(t *testing.T) {
 	}
 
 	tests := []struct {
+		name      string
 		build     *library.Build
 		container *pipeline.Container
 		repo      *library.Repo
 		want      bool
 	}{
 		{
+			name:      "build",
 			build:     _build,
 			container: _container,
 			repo:      _repo,
 			want:      false,
 		},
 		{
+			name:      "comment",
 			build:     _comment,
 			container: _container,
 			repo:      _repo,
 			want:      false,
 		},
 		{
+			name:      "deploy",
 			build:     _deploy,
 			container: _container,
 			repo:      _repo,
 			want:      false,
 		},
 		{
+			name:      "tag",
 			build:     _tag,
 			container: _container,
 			repo:      _repo,
 			want:      false,
 		},
 		{
+			name:      "skip nil",
 			build:     nil,
 			container: nil,
 			repo:      nil,

--- a/internal/step/skip_test.go
+++ b/internal/step/skip_test.go
@@ -197,10 +197,12 @@ func TestStep_Skip(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		got := Skip(test.container, test.build, test.repo)
+		t.Run(test.name, func(t *testing.T) {
+			got := Skip(test.container, test.build, test.repo)
 
-		if got != test.want {
-			t.Errorf("Skip is %v, want %v", got, test.want)
-		}
+			if got != test.want {
+				t.Errorf("Skip is %v, want %v", got, test.want)
+			}
+		})
 	}
 }

--- a/internal/step/snapshot_test.go
+++ b/internal/step/snapshot_test.go
@@ -138,7 +138,9 @@ func TestStep_Snapshot(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		Snapshot(test.container, test.build, test.client, nil, test.repo, test.step)
+		t.Run(test.name, func(t *testing.T) {
+			Snapshot(test.container, test.build, test.client, nil, test.repo, test.step)
+		})
 	}
 }
 
@@ -268,6 +270,8 @@ func TestStep_SnapshotInit(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		SnapshotInit(test.container, test.build, test.client, nil, test.repo, test.step, test.log)
+		t.Run(test.name, func(t *testing.T) {
+			SnapshotInit(test.container, test.build, test.client, nil, test.repo, test.step, test.log)
+		})
 	}
 }

--- a/internal/step/snapshot_test.go
+++ b/internal/step/snapshot_test.go
@@ -111,6 +111,7 @@ func TestStep_Snapshot(t *testing.T) {
 	}
 
 	tests := []struct {
+		name      string
 		build     *library.Build
 		client    *vela.Client
 		container *pipeline.Container
@@ -118,6 +119,7 @@ func TestStep_Snapshot(t *testing.T) {
 		step      *library.Step
 	}{
 		{
+			name:      "running step",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -125,6 +127,7 @@ func TestStep_Snapshot(t *testing.T) {
 			step:      _step,
 		},
 		{
+			name:      "exited step",
 			build:     _build,
 			client:    _client,
 			container: _exitCode,
@@ -235,6 +238,7 @@ func TestStep_SnapshotInit(t *testing.T) {
 	}
 
 	tests := []struct {
+		name      string
 		build     *library.Build
 		client    *vela.Client
 		container *pipeline.Container
@@ -243,6 +247,7 @@ func TestStep_SnapshotInit(t *testing.T) {
 		step      *library.Step
 	}{
 		{
+			name:      "running step",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -251,6 +256,7 @@ func TestStep_SnapshotInit(t *testing.T) {
 			step:      _step,
 		},
 		{
+			name:      "exited step",
 			build:     _build,
 			client:    _client,
 			container: _exitCode,

--- a/internal/step/upload_test.go
+++ b/internal/step/upload_test.go
@@ -120,6 +120,7 @@ func TestStep_Upload(t *testing.T) {
 	}
 
 	tests := []struct {
+		name      string
 		build     *library.Build
 		client    *vela.Client
 		container *pipeline.Container
@@ -127,6 +128,7 @@ func TestStep_Upload(t *testing.T) {
 		step      *library.Step
 	}{
 		{
+			name:      "running step",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -134,6 +136,7 @@ func TestStep_Upload(t *testing.T) {
 			step:      _step,
 		},
 		{
+			name:      "canceled step",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -141,6 +144,7 @@ func TestStep_Upload(t *testing.T) {
 			step:      &_canceled,
 		},
 		{
+			name:      "errored step",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -148,6 +152,7 @@ func TestStep_Upload(t *testing.T) {
 			step:      &_error,
 		},
 		{
+			name:      "pending step",
 			build:     _build,
 			client:    _client,
 			container: _container,
@@ -155,6 +160,7 @@ func TestStep_Upload(t *testing.T) {
 			step:      &_pending,
 		},
 		{
+			name:      "exited step",
 			build:     _build,
 			client:    _client,
 			container: _exitCode,

--- a/internal/step/upload_test.go
+++ b/internal/step/upload_test.go
@@ -171,6 +171,8 @@ func TestStep_Upload(t *testing.T) {
 
 	// run test
 	for _, test := range tests {
-		Upload(test.container, test.build, test.client, nil, test.repo, test.step)
+		t.Run(test.name, func(t *testing.T) {
+			Upload(test.container, test.build, test.client, nil, test.repo, test.step)
+		})
 	}
 }

--- a/internal/volume/volume_test.go
+++ b/internal/volume/volume_test.go
@@ -12,10 +12,12 @@ import (
 func TestVolume_Parse(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name   string
 		volume string
 		want   *Volume
 	}{
 		{
+			name:   "same src and dest",
 			volume: "/foo",
 			want: &Volume{
 				Source:      "/foo",
@@ -24,6 +26,7 @@ func TestVolume_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:   "different src and dest",
 			volume: "/foo:/bar",
 			want: &Volume{
 				Source:      "/foo",
@@ -32,6 +35,7 @@ func TestVolume_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:   "read-only different src and dest",
 			volume: "/foo:/bar:ro",
 			want: &Volume{
 				Source:      "/foo",
@@ -40,6 +44,7 @@ func TestVolume_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:   "read-write different src and dest",
 			volume: "/foo:/bar:rw",
 			want: &Volume{
 				Source:      "/foo",
@@ -48,6 +53,7 @@ func TestVolume_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:   "invalid",
 			volume: "/foo:/bar:/foo:bar",
 			want:   nil,
 		},
@@ -66,11 +72,13 @@ func TestVolume_Parse(t *testing.T) {
 func TestImage_ParseWithError(t *testing.T) {
 	// setup tests
 	tests := []struct {
+		name    string
 		failure bool
 		volume  string
 		want    *Volume
 	}{
 		{
+			name:    "same src and dest",
 			failure: false,
 			volume:  "/foo",
 			want: &Volume{
@@ -80,6 +88,7 @@ func TestImage_ParseWithError(t *testing.T) {
 			},
 		},
 		{
+			name:    "different src and dest",
 			failure: false,
 			volume:  "/foo:/bar",
 			want: &Volume{
@@ -89,6 +98,7 @@ func TestImage_ParseWithError(t *testing.T) {
 			},
 		},
 		{
+			name:    "read-only different src and dest",
 			failure: false,
 			volume:  "/foo:/bar:ro",
 			want: &Volume{
@@ -98,6 +108,7 @@ func TestImage_ParseWithError(t *testing.T) {
 			},
 		},
 		{
+			name:    "read-write different src and dest",
 			failure: false,
 			volume:  "/foo:/bar:rw",
 			want: &Volume{
@@ -107,6 +118,7 @@ func TestImage_ParseWithError(t *testing.T) {
 			},
 		},
 		{
+			name:    "invalid",
 			failure: true,
 			volume:  "/foo:/bar:/foo:bar",
 			want:    nil,

--- a/internal/volume/volume_test.go
+++ b/internal/volume/volume_test.go
@@ -61,11 +61,13 @@ func TestVolume_Parse(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := Parse(test.volume)
+		t.Run(test.name, func(t *testing.T) {
+			got := Parse(test.volume)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("Parse is %v, want %v", got, test.want)
-		}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("Parse is %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 
@@ -127,26 +129,28 @@ func TestImage_ParseWithError(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := ParseWithError(test.volume)
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseWithError(test.volume)
 
-		if test.failure {
-			if err == nil {
-				t.Errorf("ParseWithError should have returned err")
+			if test.failure {
+				if err == nil {
+					t.Errorf("ParseWithError should have returned err")
+				}
+
+				if !reflect.DeepEqual(got, test.want) {
+					t.Errorf("ParseWithError is %s want %s", got, test.want)
+				}
+
+				return // continue to next test
+			}
+
+			if err != nil {
+				t.Errorf("ParseWithError returned err: %v", err)
 			}
 
 			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("ParseWithError is %s want %s", got, test.want)
+				t.Errorf("ParseWithError is %v, want %v", got, test.want)
 			}
-
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("ParseWithError returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("ParseWithError is %v, want %v", got, test.want)
-		}
+		})
 	}
 }


### PR DESCRIPTION
I use Goland to run `go test`. At least with Goland, `testing.Run()` improves the output and test selection. And it makes it easier to see which subtest has failed.

As I develop and refactor, I would really like to see this everywhere. This converts all tests under `internal/` like #312 did for `runtime/`.
