### PR TITLE
fix(ci): Fix silent failures in GHA reviewdog workflow

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -23,7 +23,7 @@ jobs:
       uses: reviewdog/action-golangci-lint@v2
       with:
         github_token: ${{ secrets.github_token }}
-        go_version: 1.17
+        go_version: 1.17.9
         golangci_lint_flags: "--config=.golangci.yml"
         fail_on_error: true
         filter_mode: diff_context
@@ -41,7 +41,7 @@ jobs:
       uses: reviewdog/action-golangci-lint@v2
       with:
         github_token: ${{ secrets.github_token }}
-        go_version: 1.17
+        go_version: 1.17.9
         golangci_lint_flags: "--config=.golangci.yml"
         fail_on_error: false
         filter_mode: nofilter

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,6 +5,10 @@ name: reviewdog
 on:
   pull_request:
 
+# NOTE: We have to specify `go_version: 1.17` because the action was installing 1.18.
+# 1.18, in turn, is not fully supported by golangci-lint yet, and it can fail silently:
+# see: https://github.com/reviewdog/action-golangci-lint/issues/249
+
 # pipeline to execute
 jobs:
   diff-review:
@@ -19,6 +23,7 @@ jobs:
       uses: reviewdog/action-golangci-lint@v2
       with:
         github_token: ${{ secrets.github_token }}
+        go_version: 1.17
         golangci_lint_flags: "--config=.golangci.yml"
         fail_on_error: true
         filter_mode: diff_context
@@ -36,6 +41,7 @@ jobs:
       uses: reviewdog/action-golangci-lint@v2
       with:
         github_token: ${{ secrets.github_token }}
+        go_version: 1.17
         golangci_lint_flags: "--config=.golangci.yml"
         fail_on_error: false
         filter_mode: nofilter

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   diff-review:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.17
     steps:
     - name: clone
       uses: actions/checkout@v3
@@ -31,8 +29,6 @@ jobs:
 
   full-review:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.17
     steps:
     - name: clone
       uses: actions/checkout@v3

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         github_token: ${{ secrets.github_token }}
         go_version: 1.17.9
-        golangci_lint_flags: "--config=.golangci.yml"
+        golangci_lint_flags: "--config=.golangci.yml --verbose"
         fail_on_error: true
         filter_mode: diff_context
         reporter: github-pr-review
@@ -38,6 +38,6 @@ jobs:
       with:
         github_token: ${{ secrets.github_token }}
         go_version: 1.17.9
-        golangci_lint_flags: "--config=.golangci.yml"
+        golangci_lint_flags: "--config=.golangci.yml --verbose"
         fail_on_error: false
         filter_mode: nofilter


### PR DESCRIPTION
It was installing 1.18 which can panic or have a variety of silent failures.
See: https://github.com/reviewdog/action-golangci-lint/issues/249

Here is an example silent failures:
- 1.18 was installed: https://github.com/go-vela/worker/runs/6098658651?check_suite_focus=true#step:4:18
- failed: https://github.com/go-vela/worker/runs/6098658651?check_suite_focus=true#step:4:84

```
  /__w/_temp/reviewdog-F3Z0zl/golangci-lint-1.45.2-linux-amd64/golangci-lint run --out-format line-number --config=.golangci.yml
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
  /__w/_temp/reviewdog-F3Z0zl/reviewdog -f=golangci-lint -name=golangci -reporter=github-pr-review -filter-mode=diff_context -fail-on-error=true -level=error
```

The reviewdog action always installs go, so using the container doesn't save us anything any more. So, I dropped that.

And, it was still giving me `timeout` errors. However, those errors do not seem to present themselves with `--verbose` mode. Plus, with `--verbose`, if it happens again, we'll have more details about what is timing out.