### PR TITLE
bugfix(k8s): do not log false-positive error when pause image is running

### DIFF
--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -53,17 +53,9 @@ func (c *client) InspectContainer(ctx context.Context, ctn *pipeline.Container) 
 
 		// avoid a panic if the build ends without terminating all containers
 		if cst.State.Terminated == nil {
-			for _, container := range pod.Spec.Containers {
-				if cst.Name != container.Name {
-					continue
-				}
-
-				// steps that were not executed will still be "running" the pause image as expected.
-				if container.Image == pauseImage {
-					return nil
-				}
-
-				break
+			// steps that were not executed will still be "running" the pause image as expected.
+			if cst.Image == pauseImage || cst.Image == image.Parse(pauseImage) {
+				return nil
 			}
 
 			return fmt.Errorf("expected container %s to be terminated, got %v", ctn.ID, cst.State)

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-vela/types/pipeline"
+	"github.com/go-vela/worker/internal/image"
 	velav1alpha1 "github.com/go-vela/worker/runtime/kubernetes/apis/vela/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
@@ -52,6 +53,53 @@ func TestKubernetes_InspectContainer(t *testing.T) {
 							State: v1.ContainerState{
 								Running: &v1.ContainerStateRunning{},
 							},
+							Image: _container.Image,
+						},
+					},
+				},
+			},
+			container: _container,
+		},
+		{
+			name:    "build stops before container execution with raw pauseImage",
+			failure: false,
+			pod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Spec:       _pod.Spec,
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "step-github-octocat-1-clone",
+							State: v1.ContainerState{
+								Running: &v1.ContainerStateRunning{},
+							},
+							// container not patched yet with correct image
+							Image: pauseImage,
+						},
+					},
+				},
+			},
+			container: _container,
+		},
+		{
+			name:    "build stops before container execution with canonical pauseImage",
+			failure: false,
+			pod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Spec:       _pod.Spec,
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "step-github-octocat-1-clone",
+							State: v1.ContainerState{
+								Running: &v1.ContainerStateRunning{},
+							},
+							// container not patched yet with correct image
+							Image: image.Parse(pauseImage),
 						},
 					},
 				},
@@ -411,6 +459,7 @@ func TestKubernetes_WaitContainer(t *testing.T) {
 									ExitCode: 0,
 								},
 							},
+							Image: "alpine:latest",
 						},
 						{
 							Name: "step-github-octocat-1-clone",
@@ -420,6 +469,7 @@ func TestKubernetes_WaitContainer(t *testing.T) {
 									ExitCode: 0,
 								},
 							},
+							Image: "target/vela-git:v0.4.0",
 						},
 					},
 				},

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -106,6 +106,7 @@ var (
 							ExitCode: 0,
 						},
 					},
+					Image: "target/vela-git:v0.4.0",
 				},
 				{
 					Name: "step-github-octocat-1-echo",
@@ -115,6 +116,7 @@ var (
 							ExitCode: 0,
 						},
 					},
+					Image: "alpine:latest",
 				},
 			},
 		},


### PR DESCRIPTION
Follow up for #308 which successfully prevented a panic, but was still logging errors (about the pause image running) when it shouldn't have. It seems the test case added in #308 did not cover the pause image running, so this adds a couple of tests for that to ensure that that does NOT fail.

We have to use the canonical (parsed) pause image or it won't match at runtime:
https://github.com/go-vela/worker/blob/c25339835ea70c10e00d947ab3c08e2ab31b2135/runtime/kubernetes/container.go#L138

I also check for the simple non-canonical image name as well to simplify any unrelated tests that might incidentally use this.

~Also add a helpful note/comment about ContainerState objects.~