### PR TITLE
bugfix: make sure kubernetes log streaming gets canceled with build

### DIFF
--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -238,6 +238,10 @@ func (c *client) setupContainerEnvironment(ctn *pipeline.Container) error {
 func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io.ReadCloser, error) {
 	c.Logger.Tracef("tailing output for container %s", ctn.ID)
 
+	// create a logsContext that will be canceled at the end of this
+	logsContext, logsDone := context.WithCancel(ctx)
+	defer logsDone()
+
 	// create object to store container logs
 	var logs io.ReadCloser
 
@@ -261,7 +265,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 		stream, err := c.Kubernetes.CoreV1().
 			Pods(c.config.Namespace).
 			GetLogs(c.Pod.ObjectMeta.Name, opts).
-			Stream(context.Background())
+			Stream(logsContext)
 		if err != nil {
 			c.Logger.Errorf("%v", err)
 			return false, nil
@@ -305,7 +309,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 	// perform the function to capture logs with periodic backoff
 	//
 	// https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait?tab=doc#ExponentialBackoff
-	err := wait.ExponentialBackoff(backoff, logsFunc)
+	err := wait.ExponentialBackoffWithContext(logsContext, backoff, logsFunc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
While implementing #304 (improving context usage) and then #317 (improve worker log context management) I noticed that the Kubernetes Runtime's `TailContainer` ignores the context as it makes its requests. This fixes that so that tailing will stop if the streamCtx (which gets passed to TailContainer) is canceled.