### PR TITLE
feat(k8s): Make RunContainer detect/report more error conditions like image pull errors

### DIFF
--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -219,7 +219,7 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 	close(c.PodTracker.Ready)
 
 	// wait for the PodTracker caches to populate before creating the pipeline pod.
-	if ok := cache.WaitForCacheSync(ctx.Done(), c.PodTracker.PodSynced); !ok {
+	if ok := cache.WaitForCacheSync(ctx.Done(), c.PodTracker.PodSynced, c.PodTracker.EventSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -443,20 +443,25 @@ func (p *podTracker) inspectContainerStatuses(pod *v1.Pod) {
 		} else if cst.State.Waiting != nil &&
 			(cst.State.Waiting.Reason == reasonBackOff || cst.State.Waiting.Reason == reasonFailed) &&
 			strings.Contains(cst.State.Waiting.Message, tracker.Image) {
-			// imitate an event to make sure we catch it.
-			tracker.ImagePullErrors <- &v1.Event{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: p.Namespace,
-				},
-				InvolvedObject: v1.ObjectReference{
-					Kind:      "Pod",
-					Name:      p.Name,
-					Namespace: p.Namespace,
-					FieldPath: fmt.Sprintf("spec.containers{%s}", tracker.Name),
-				},
-				Reason:  cst.State.Waiting.Reason,
-				Message: cst.State.Waiting.Message,
-			}
+			// inspectContainerStatuses should return as quickly as possible
+			// writing to the channel can block when nothing is receiving,
+			// so fire it off in a goroutine.
+			go func() {
+				// imitate an event to make sure we catch it.
+				tracker.ImagePullErrors <- &v1.Event{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: p.Namespace,
+					},
+					InvolvedObject: v1.ObjectReference{
+						Kind:      "Pod",
+						Name:      p.Name,
+						Namespace: p.Namespace,
+						FieldPath: fmt.Sprintf("spec.containers{%s}", tracker.Name),
+					},
+					Reason:  cst.State.Waiting.Reason,
+					Message: cst.State.Waiting.Message,
+				}
+			}()
 		}
 	}
 }

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -413,7 +413,7 @@ func (p *podTracker) inspectContainerStatuses(pod *v1.Pod) {
 			tracker.runningOnce.Do(func() {
 				p.Logger.Debugf("container running: %s in pod %s, %v", cst.Name, p.TrackedPod, cst)
 
-				// let WaitContainer know the container is terminated
+				// let RunContainer know the container is running
 				close(tracker.Running)
 			})
 		}

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -364,6 +364,13 @@ func (p *podTracker) inspectContainerStatuses(pod *v1.Pod) {
 				// let WaitContainer know the container is terminated
 				close(tracker.Terminated)
 			})
+		} else if cst.State.Running != nil {
+			tracker.runningOnce.Do(func() {
+				p.Logger.Debugf("container running: %s in pod %s, %v", cst.Name, p.TrackedPod, cst)
+
+				// let WaitContainer know the container is terminated
+				close(tracker.Running)
+			})
 		}
 	}
 }

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -322,7 +322,14 @@ func (c *client) WaitContainer(ctx context.Context, ctn *pipeline.Container) err
 	}
 
 	// wait for the container terminated signal
-	<-tracker.Terminated
+	select {
+	case <-tracker.Terminated:
+		// container is terminated
+		break
+	case <-ctx.Done():
+		// build was canceled
+		break
+	}
 
 	return nil
 }

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -354,6 +354,12 @@ func (p *podTracker) inspectContainerStatuses(pod *v1.Pod) {
 		// cst.LastTerminationState has details about the kubernetes/pause image's exit.
 		// cst.RestartCount is 1 at exit due to switch from kubernetes/pause to final image.
 
+		if cst.Image != tracker.Image {
+			// we don't care if the pause image has terminated or is running
+			p.Logger.Tracef("container %s expected image %s, got %s", cst.Name, tracker.Image, cst.Image)
+			continue
+		}
+
 		// check if the container is in a terminated state
 		//
 		// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#ContainerState

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -549,6 +549,7 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 		name       string
 		trackedPod string
 		ctnName    string
+		ctnImage   string
 		terminated bool
 		pod        *v1.Pod
 	}{
@@ -556,6 +557,7 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 			name:       "container is terminated",
 			trackedPod: "test/github-octocat-1",
 			ctnName:    "step-github-octocat-1-clone",
+			ctnImage:   "target/vela-git:v0.4.0",
 			terminated: true,
 			pod:        _pod,
 		},
@@ -563,6 +565,7 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 			name:       "pod is pending",
 			trackedPod: "test/github-octocat-1",
 			ctnName:    "step-github-octocat-1-clone",
+			ctnImage:   "target/vela-git:v0.4.0",
 			terminated: false,
 			pod: &v1.Pod{
 				ObjectMeta: _pod.ObjectMeta,
@@ -577,6 +580,7 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 			name:       "container is running",
 			trackedPod: "test/github-octocat-1",
 			ctnName:    "step-github-octocat-1-clone",
+			ctnImage:   "target/vela-git:v0.4.0",
 			terminated: false,
 			pod: &v1.Pod{
 				ObjectMeta: _pod.ObjectMeta,
@@ -599,6 +603,7 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 			name:       "pod has an untracked container",
 			trackedPod: "test/github-octocat-1",
 			ctnName:    "step-github-octocat-1-clone",
+			ctnImage:   "target/vela-git:v0.4.0",
 			terminated: true,
 			pod: &v1.Pod{
 				ObjectMeta: _pod.ObjectMeta,
@@ -631,6 +636,7 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctnTracker := containerTracker{
 				Name:       test.ctnName,
+				Image:      test.ctnImage,
 				Running:    make(chan struct{}),
 				Terminated: make(chan struct{}),
 			}

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -220,6 +220,19 @@ func TestKubernetes_RunContainer(t *testing.T) {
 			oldPod:      _stepsPodBeforeRunStep,
 			newPod:      _stepsPodWithRunningStep,
 		},
+		{
+			name:      "if client.Pod.Spec is empty podTracker fails",
+			failure:   true,
+			container: _container,
+			oldPod:    _pod,
+			newPod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Status:     _pod.Status,
+				// if client.Pod.Spec is empty, podTracker will fail
+				//Spec:       _pod.Spec,
+			},
+		},
 	}
 
 	// run tests

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -590,7 +590,56 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 					Phase: v1.PodRunning,
 					ContainerStatuses: []v1.ContainerStatus{
 						{
-							Name: "step-github-octocat-1-clone",
+							Name:  "step-github-octocat-1-clone",
+							Image: "target/vela-git:v0.4.0",
+							State: v1.ContainerState{
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "container is still running pause image",
+			trackedPod: "test/github-octocat-1",
+			ctnName:    "step-github-octocat-1-clone",
+			ctnImage:   "target/vela-git:v0.4.0",
+			terminated: false,
+			pod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Spec:       _pod.Spec,
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "step-github-octocat-1-clone",
+							Image: pauseImage,
+							State: v1.ContainerState{
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "container is still running pause image",
+			trackedPod: "test/github-octocat-1",
+			ctnName:    "step-github-octocat-1-clone",
+			ctnImage:   "target/vela-git:v0.4.0",
+			terminated: false,
+			pod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Spec:       _pod.Spec,
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "step-github-octocat-1-clone",
+							Image: image.Parse(pauseImage),
 							State: v1.ContainerState{
 								Running: &v1.ContainerStateRunning{},
 							},
@@ -613,7 +662,8 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 					Phase: v1.PodRunning,
 					ContainerStatuses: []v1.ContainerStatus{
 						{
-							Name: "step-github-octocat-1-clone",
+							Name:  "step-github-octocat-1-clone",
+							Image: "target/vela-git:v0.4.0",
 							State: v1.ContainerState{
 								Terminated: &v1.ContainerStateTerminated{
 									Reason:   "Completed",
@@ -622,7 +672,8 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 							},
 						},
 						{
-							Name: "injected-by-admissions-controller",
+							Name:  "injected-by-admissions-controller",
+							Image: "target/vela-git:v0.4.0",
 							State: v1.ContainerState{
 								Running: &v1.ContainerStateRunning{},
 							},

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/worker/internal/image"
 	velav1alpha1 "github.com/go-vela/worker/runtime/kubernetes/apis/vela/v1alpha1"
@@ -337,7 +338,7 @@ func TestKubernetes_SetupContainer(t *testing.T) {
 			wantFromTemplate: nil,
 		},
 		{
-			name:    "step-echo",
+			name:    "step-echo-pull always",
 			failure: false,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -348,7 +349,79 @@ func TestKubernetes_SetupContainer(t *testing.T) {
 				Image:       "alpine:latest",
 				Name:        "echo",
 				Number:      2,
-				Pull:        "always",
+				Pull:        constants.PullAlways,
+			},
+			opts:             nil,
+			wantPrivileged:   false,
+			wantFromTemplate: nil,
+		},
+		{
+			name:    "step-echo-pull never",
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_echo",
+				Commands:    []string{"echo", "hello"},
+				Directory:   "/vela/src/github.com/octocat/helloworld",
+				Environment: map[string]string{"FOO": "bar"},
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      2,
+				Pull:        constants.PullNever,
+			},
+			opts:             nil,
+			wantPrivileged:   false,
+			wantFromTemplate: nil,
+		},
+		{
+			name:    "step-echo-pull on start",
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_echo",
+				Commands:    []string{"echo", "hello"},
+				Directory:   "/vela/src/github.com/octocat/helloworld",
+				Environment: map[string]string{"FOO": "bar"},
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      2,
+				Pull:        constants.PullOnStart,
+			},
+			opts:             nil,
+			wantPrivileged:   false,
+			wantFromTemplate: nil,
+		},
+		{
+			name:    "step-echo-pull not present",
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_echo",
+				Commands:    []string{"echo", "hello"},
+				Directory:   "/vela/src/github.com/octocat/helloworld",
+				Environment: map[string]string{"FOO": "bar"},
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      2,
+				Pull:        constants.PullNotPresent,
+			},
+			opts:             nil,
+			wantPrivileged:   false,
+			wantFromTemplate: nil,
+		},
+		{
+			name:    "step-echo-pull default",
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_echo",
+				Commands:    []string{"echo", "hello"},
+				Directory:   "/vela/src/github.com/octocat/helloworld",
+				Environment: map[string]string{"FOO": "bar"},
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      2,
+				Pull:        "",
 			},
 			opts:             nil,
 			wantPrivileged:   false,

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -631,6 +631,7 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctnTracker := containerTracker{
 				Name:       test.ctnName,
+				Running:    make(chan struct{}),
 				Terminated: make(chan struct{}),
 			}
 			podTracker := podTracker{

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -805,9 +805,6 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 				ImagePullErrors: make(chan *v1.Event),
 				Running:         make(chan struct{}),
 				Terminated:      make(chan struct{}),
-				Events: func() ([]*v1.Event, error) {
-					return nil, nil
-				},
 			}
 			podTracker := podTracker{
 				Logger:     logger,

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -639,6 +639,9 @@ func Test_podTracker_inspectContainerStatuses(t *testing.T) {
 				Image:      test.ctnImage,
 				Running:    make(chan struct{}),
 				Terminated: make(chan struct{}),
+				Events: func() ([]*v1.Event, error) {
+					return nil, nil
+				},
 			}
 			podTracker := podTracker{
 				Logger:     logger,

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -181,29 +181,257 @@ func TestKubernetes_RunContainer(t *testing.T) {
 		failure   bool
 		container *pipeline.Container
 		pipeline  *pipeline.Build
-		pod       *v1.Pod
+		oldPod    *v1.Pod
+		newPod    *v1.Pod
 		volumes   []string
 	}{
 		{
-			name:      "stages",
+			name:      "stages-step starts running",
 			failure:   false,
 			container: _container,
 			pipeline:  _stages,
-			pod:       _pod,
+			oldPod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "step-github-octocat-1-clone-clone",
+							Image: pauseImage, // stage+step is not running yet
+							State: v1.ContainerState{
+								// pause is running, not the step image
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name:  "step-github-octocat-1-echo-echo",
+							Image: pauseImage, // stage+step is not running yet
+							State: v1.ContainerState{
+								// pause is running, not the step image
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name:  "service-github-octocat-1-postgres",
+							Image: "postgres:12-alpine",
+							State: v1.ContainerState{
+								// service is running
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "step-github-octocat-1-clone-clone",
+							Image:           pauseImage, // not running yet
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+						{
+							Name:            "step-github-octocat-1-echo-echo",
+							Image:           pauseImage, // not running yet
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+						{
+							Name:            "service-github-octocat-1-postgres",
+							Image:           "postgres:12-alpine",
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+					},
+					HostAliases: _pod.Spec.HostAliases,
+					Volumes:     _pod.Spec.Volumes,
+				},
+			},
+			newPod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "step-github-octocat-1-clone",
+							Image: "target/vela-git:v0.4.0",
+							State: v1.ContainerState{
+								// stage+step is running
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name:  "step-github-octocat-1-echo",
+							Image: pauseImage,
+							State: v1.ContainerState{
+								// pause is running, not the step image
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name:  "service-github-octocat-1-postgres",
+							Image: "postgres:12-alpine",
+							State: v1.ContainerState{
+								// service is running
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "step-github-octocat-1-clone",
+							Image:           "target/vela-git:v0.4.0", // running
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+						{
+							Name:            "step-github-octocat-1-echo",
+							Image:           pauseImage, // not running yet
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+						{
+							Name:            "service-github-octocat-1-postgres",
+							Image:           "postgres:12-alpine",
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+					},
+					HostAliases: _pod.Spec.HostAliases,
+					Volumes:     _pod.Spec.Volumes,
+				},
+			},
 		},
 		{
-			name:      "steps",
+			name:      "steps-step starts running",
 			failure:   false,
 			container: _container,
 			pipeline:  _steps,
-			pod:       _pod,
+			oldPod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "step-github-octocat-1-clone",
+							Image: pauseImage, // step is not running yet
+							State: v1.ContainerState{
+								// pause is running, not the step image
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name:  "step-github-octocat-1-echo",
+							Image: pauseImage, // step is not running yet
+							State: v1.ContainerState{
+								// pause is running, not the step image
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name:  "service-github-octocat-1-postgres",
+							Image: "postgres:12-alpine",
+							State: v1.ContainerState{
+								// service is running
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "step-github-octocat-1-clone",
+							Image:           pauseImage, // not running yet
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+						{
+							Name:            "step-github-octocat-1-echo",
+							Image:           pauseImage, // not running yet
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+						{
+							Name:            "service-github-octocat-1-postgres",
+							Image:           "postgres:12-alpine",
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+					},
+					HostAliases: _pod.Spec.HostAliases,
+					Volumes:     _pod.Spec.Volumes,
+				},
+			},
+			newPod: &v1.Pod{
+				ObjectMeta: _pod.ObjectMeta,
+				TypeMeta:   _pod.TypeMeta,
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "step-github-octocat-1-clone",
+							Image: "target/vela-git:v0.4.0",
+							State: v1.ContainerState{
+								// step is running
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name:  "step-github-octocat-1-echo",
+							Image: pauseImage,
+							State: v1.ContainerState{
+								// pause is running, not the step image
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+						{
+							Name:  "service-github-octocat-1-postgres",
+							Image: "postgres:12-alpine",
+							State: v1.ContainerState{
+								// service is running
+								Running: &v1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "step-github-octocat-1-clone",
+							Image:           "target/vela-git:v0.4.0", // running
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+						{
+							Name:            "step-github-octocat-1-echo",
+							Image:           pauseImage, // not running yet
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+						{
+							Name:            "service-github-octocat-1-postgres",
+							Image:           "postgres:12-alpine",
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+					},
+					HostAliases: _pod.Spec.HostAliases,
+					Volumes:     _pod.Spec.Volumes,
+				},
+			},
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_engine, err := NewMock(test.pod)
+			// set up the fake k8s clientset so that it returns the final/updated state
+			_engine, err := NewMock(test.newPod)
 			if err != nil {
 				t.Errorf("unable to create runtime engine: %v", err)
 			}
@@ -211,6 +439,15 @@ func TestKubernetes_RunContainer(t *testing.T) {
 			if len(test.volumes) > 0 {
 				_engine.config.Volumes = test.volumes
 			}
+
+			// RunContainer waits for the container to be running before returning
+			go func() {
+				oldPod := test.oldPod.DeepCopy()
+				oldPod.SetResourceVersion("older")
+
+				// simulate a re-sync/PodUpdate event
+				_engine.PodTracker.HandlePodUpdate(oldPod, _engine.Pod)
+			}()
 
 			err = _engine.RunContainer(context.Background(), test.container, test.pipeline)
 

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -5,6 +5,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-vela/types/pipeline"
@@ -564,3 +565,19 @@ var (
 		},
 	}
 )
+
+func mockContainerEvent(pod *v1.Pod, ctnName, reason, message string) *v1.Event {
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pod.ObjectMeta.Namespace,
+		},
+		InvolvedObject: v1.ObjectReference{
+			Kind:      pod.TypeMeta.Kind,
+			Name:      pod.ObjectMeta.Name,
+			Namespace: pod.ObjectMeta.Namespace,
+			FieldPath: fmt.Sprintf("spec.containers{%s}", ctnName),
+		},
+		Reason:  reason,
+		Message: message,
+	}
+}

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -567,15 +567,29 @@ var (
 )
 
 func mockContainerEvent(pod *v1.Pod, ctnName, reason, message string) *v1.Event {
+	var fieldPath string
+	if ctnName != "" {
+		fieldPath = fmt.Sprintf("spec.containers{%s}", ctnName)
+	} else {
+		fieldPath = "spec.containers[2]"
+	}
+
 	return &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:      _pod.ObjectMeta.Name + ".16ea333d810392b7",
 			Namespace: pod.ObjectMeta.Namespace,
 		},
 		InvolvedObject: v1.ObjectReference{
 			Kind:      pod.TypeMeta.Kind,
 			Name:      pod.ObjectMeta.Name,
 			Namespace: pod.ObjectMeta.Namespace,
-			FieldPath: fmt.Sprintf("spec.containers{%s}", ctnName),
+			FieldPath: fieldPath,
+		},
+		ReportingController: "",
+		ReportingInstance:   "",
+		Source: v1.EventSource{
+			Component: "kubelet",
+			Host:      "k8s-worker",
 		},
 		Reason:  reason,
 		Message: message,

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -80,6 +80,16 @@ var (
 		Pull:        "always",
 	}
 
+	_stagesContainer = &pipeline.Container{
+		ID:          "step-github-octocat-1-clone-clone",
+		Directory:   _container.Directory,
+		Environment: _container.Environment,
+		Image:       _container.Image,
+		Name:        _container.Name,
+		Number:      _container.Number,
+		Pull:        _container.Pull,
+	}
+
 	_pod = &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "github-octocat-1",
@@ -155,6 +165,122 @@ var (
 					},
 				},
 			},
+		},
+	}
+
+	_stepsPodBeforeRunStep = &v1.Pod{
+		ObjectMeta: _pod.ObjectMeta,
+		TypeMeta:   _pod.TypeMeta,
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "step-github-octocat-1-clone",
+					Image: pauseImage, // step is not running yet
+					State: v1.ContainerState{
+						// pause is running, not the step image
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name:  "step-github-octocat-1-echo",
+					Image: pauseImage, // step is not running yet
+					State: v1.ContainerState{
+						// pause is running, not the step image
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name:  "service-github-octocat-1-postgres",
+					Image: "postgres:12-alpine",
+					State: v1.ContainerState{
+						// service is running
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "step-github-octocat-1-clone",
+					Image:           pauseImage, // not running yet
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+				{
+					Name:            "step-github-octocat-1-echo",
+					Image:           pauseImage, // not running yet
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+				{
+					Name:            "service-github-octocat-1-postgres",
+					Image:           "postgres:12-alpine",
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+			},
+			HostAliases: _pod.Spec.HostAliases,
+			Volumes:     _pod.Spec.Volumes,
+		},
+	}
+
+	_stepsPodWithRunningStep = &v1.Pod{
+		ObjectMeta: _pod.ObjectMeta,
+		TypeMeta:   _pod.TypeMeta,
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "step-github-octocat-1-clone",
+					Image: "target/vela-git:v0.4.0",
+					State: v1.ContainerState{
+						// step is running
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name:  "step-github-octocat-1-echo",
+					Image: pauseImage,
+					State: v1.ContainerState{
+						// pause is running, not the step image
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name:  "service-github-octocat-1-postgres",
+					Image: "postgres:12-alpine",
+					State: v1.ContainerState{
+						// service is running
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "step-github-octocat-1-clone",
+					Image:           "target/vela-git:v0.4.0", // running
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+				{
+					Name:            "step-github-octocat-1-echo",
+					Image:           pauseImage, // not running yet
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+				{
+					Name:            "service-github-octocat-1-postgres",
+					Image:           "postgres:12-alpine",
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+			},
+			HostAliases: _pod.Spec.HostAliases,
+			Volumes:     _pod.Spec.Volumes,
 		},
 	}
 
@@ -319,6 +445,122 @@ var (
 					},
 				},
 			},
+		},
+	}
+
+	_stagesPodBeforeRunStep = &v1.Pod{
+		ObjectMeta: _stagesPod.ObjectMeta,
+		TypeMeta:   _stagesPod.TypeMeta,
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "step-github-octocat-1-clone-clone",
+					Image: pauseImage, // step is not running yet
+					State: v1.ContainerState{
+						// pause is running, not the step image
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name:  "step-github-octocat-1-echo-echo",
+					Image: pauseImage, // step is not running yet
+					State: v1.ContainerState{
+						// pause is running, not the step image
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name:  "service-github-octocat-1-postgres",
+					Image: "postgres:12-alpine",
+					State: v1.ContainerState{
+						// service is running
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "step-github-octocat-1-clone-clone",
+					Image:           pauseImage, // not running yet
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+				{
+					Name:            "step-github-octocat-1-echo-echo",
+					Image:           pauseImage, // not running yet
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+				{
+					Name:            "service-github-octocat-1-postgres",
+					Image:           "postgres:12-alpine",
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+			},
+			HostAliases: _stagesPod.Spec.HostAliases,
+			Volumes:     _stagesPod.Spec.Volumes,
+		},
+	}
+
+	_stagesPodWithRunningStep = &v1.Pod{
+		ObjectMeta: _stagesPod.ObjectMeta,
+		TypeMeta:   _stagesPod.TypeMeta,
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "step-github-octocat-1-clone-clone",
+					Image: "target/vela-git:v0.4.0",
+					State: v1.ContainerState{
+						// step is running
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name:  "step-github-octocat-1-echo-echo",
+					Image: pauseImage,
+					State: v1.ContainerState{
+						// pause is running, not the step image
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name:  "service-github-octocat-1-postgres",
+					Image: "postgres:12-alpine",
+					State: v1.ContainerState{
+						// service is running
+						Running: &v1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "step-github-octocat-1-clone-clone",
+					Image:           "target/vela-git:v0.4.0", // running
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+				{
+					Name:            "step-github-octocat-1-echo-echo",
+					Image:           pauseImage, // not running yet
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+				{
+					Name:            "service-github-octocat-1-postgres",
+					Image:           "postgres:12-alpine",
+					WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+					ImagePullPolicy: v1.PullAlways,
+				},
+			},
+			HostAliases: _stagesPod.Spec.HostAliases,
+			Volumes:     _stagesPod.Spec.Volumes,
 		},
 	}
 )

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -37,9 +37,9 @@ type containerTracker struct {
 	ImagePulled chan struct{}
 	// ImagePullErrors collects any image pull errors.
 	ImagePullErrors chan *v1.Event
-	// runningOnce ensures that the Terminated channel only gets closed once.
+	// runningOnce ensures that the Running channel only gets closed once.
 	runningOnce sync.Once
-	// Running will be closed once the container reaches a terminal state.
+	// Running will be closed once the container reaches a running state.
 	Running chan struct{}
 	// terminatedOnce ensures that the Terminated channel only gets closed once.
 	terminatedOnce sync.Once

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -58,6 +58,8 @@ type podTracker struct {
 	// https://pkg.go.dev/github.com/sirupsen/logrus#Entry
 	Logger *logrus.Entry
 
+	// Name is the Name of the tracked pod
+	Name string
 	// Namespace is the Namespace of the tracked pod
 	Namespace string
 	// TrackedPod is the Namespace/Name of the tracked pod
@@ -373,6 +375,7 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 	// initialize podTracker
 	tracker := podTracker{
 		Logger:               log,
+		Name:                 pod.ObjectMeta.Name,
 		Namespace:            pod.ObjectMeta.Namespace,
 		TrackedPod:           trackedPod,
 		informerFactory:      informerFactory,

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -270,8 +270,8 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 
 	log.Tracef("creating PodTracker for pod %s", trackedPod)
 
-	// create label selector for watching the pod
-	selector, err := labels.NewRequirement(
+	// create labelSelector for watching the pod
+	labelSelector, err := labels.NewRequirement(
 		"pipeline",
 		selection.Equals,
 		[]string{fields.EscapeValue(pod.ObjectMeta.Name)},
@@ -291,7 +291,7 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 		defaultResync,
 		kubeinformers.WithNamespace(pod.ObjectMeta.Namespace),
 		kubeinformers.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
-			listOptions.LabelSelector = selector.String()
+			listOptions.LabelSelector = labelSelector.String()
 		}),
 	)
 	podInformer := informerFactory.Core().V1().Pods()

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -162,9 +162,8 @@ func (p *podTracker) HandleEventUpdate(oldObj, newObj interface{}) {
 }
 
 // HandleEventDelete is an DeleteFunc for cache.ResourceEventHandlerFuncs for Events.
-func (p *podTracker) HandleEventDelete(oldObj interface{}) {
-	// TODO: do something with the (possible) event
-}
+//func (p *podTracker) HandleEventDelete(oldObj interface{}) {
+//}
 
 // Start kicks off the API calls to start populating the cache.
 // There is no need to run this in a separate goroutine (ie go podTracker.Start(ctx)).
@@ -262,7 +261,8 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 	eventInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    tracker.HandleEventAdd,
 		UpdateFunc: tracker.HandleEventUpdate,
-		DeleteFunc: tracker.HandleEventDelete,
+		// events get deleted after some time, which we ignore.
+		//DeleteFunc: tracker.HandleEventDelete,
 	})
 
 	return &tracker, nil

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -208,17 +208,6 @@ func (p *podTracker) HandleEventUpdate(oldObj, newObj interface{}) {
 	p.inspectContainerEvent(newEvent)
 }
 
-// HandleEventDelete is an DeleteFunc for cache.ResourceEventHandlerFuncs for Events.
-//func (p *podTracker) HandleEventDelete(oldObj interface{}) {
-//	oldEvent := p.getTrackedPodEvent(oldObj)
-//	if oldEvent == nil {
-//		// not valid or not for our tracked pod
-//		return
-//	}
-//
-//	p.Logger.Tracef("handling event delete event for %s", p.TrackedPod)
-//}
-
 // getTrackedPodEvent tries to convert the obj into an Event and makes sure it is for the tracked Pod.
 // This should only be used by the funcs of cache.ResourceEventHandlerFuncs.
 func (p *podTracker) getTrackedPodEvent(obj interface{}) *v1.Event {
@@ -366,8 +355,7 @@ func newPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.Po
 	eventInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    tracker.HandleEventAdd,
 		UpdateFunc: tracker.HandleEventUpdate,
-		// events get deleted after some time, which we ignore.
-		//DeleteFunc: tracker.HandleEventDelete,
+		// No DeleteFunc as events get deleted after some time, which we ignore.
 	})
 
 	return &tracker, nil

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -31,6 +31,12 @@ type containerTracker struct {
 	// Image is the final image of the container
 	Image string
 
+	// imagePulledOnce ensures that the ImagePulled channel only gets closed once.
+	imagePulledOnce sync.Once
+	// ImagePulled will be closed once the container's image has been pulled.
+	ImagePulled chan struct{}
+	// ImagePullErrors collects any image pull errors.
+	ImagePullErrors chan *v1.Event
 	// runningOnce ensures that the Terminated channel only gets closed once.
 	runningOnce sync.Once
 	// Running will be closed once the container reaches a terminal state.

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -28,6 +28,9 @@ import (
 type containerTracker struct {
 	// Name is the name of the container
 	Name string
+	// Image is the final image of the container
+	Image string
+
 	// runningOnce ensures that the Terminated channel only gets closed once.
 	runningOnce sync.Once
 	// Running will be closed once the container reaches a terminal state.
@@ -269,6 +272,7 @@ func (p *podTracker) TrackContainers(containers []v1.Container) {
 	for _, ctn := range containers {
 		p.Containers[ctn.Name] = &containerTracker{
 			Name:       ctn.Name,
+			Image:      ctn.Image,
 			Running:    make(chan struct{}),
 			Terminated: make(chan struct{}),
 		}

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -28,6 +28,10 @@ import (
 type containerTracker struct {
 	// Name is the name of the container
 	Name string
+	// runningOnce ensures that the Terminated channel only gets closed once.
+	runningOnce sync.Once
+	// Running will be closed once the container reaches a terminal state.
+	Running chan struct{}
 	// terminatedOnce ensures that the Terminated channel only gets closed once.
 	terminatedOnce sync.Once
 	// Terminated will be closed once the container reaches a terminal state.
@@ -265,6 +269,7 @@ func (p *podTracker) TrackContainers(containers []v1.Container) {
 	for _, ctn := range containers {
 		p.Containers[ctn.Name] = &containerTracker{
 			Name:       ctn.Name,
+			Running:    make(chan struct{}),
 			Terminated: make(chan struct{}),
 		}
 	}

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -45,7 +45,6 @@ type containerTracker struct {
 	terminatedOnce sync.Once
 	// Terminated will be closed once the container reaches a terminal state.
 	Terminated chan struct{}
-	// TODO: collect streaming logs here before TailContainer is called
 
 	// Events is a function that returns a list of kubernetes events
 	// related to the tracked container.
@@ -286,10 +285,12 @@ func (p *podTracker) TrackContainers(containers []v1.Container) {
 
 	for _, ctn := range containers {
 		p.Containers[ctn.Name] = &containerTracker{
-			Name:       ctn.Name,
-			Image:      ctn.Image,
-			Running:    make(chan struct{}),
-			Terminated: make(chan struct{}),
+			Name:            ctn.Name,
+			Image:           ctn.Image,
+			ImagePulled:     make(chan struct{}),
+			ImagePullErrors: make(chan *v1.Event),
+			Running:         make(chan struct{}),
+			Terminated:      make(chan struct{}),
 			Events: func() ([]*v1.Event, error) {
 				// EventLister only offers a labelSelector,
 				// but we need a fieldSelector for events,

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -162,11 +162,14 @@ func (p *podTracker) HandleEventAdd(newObj interface{}) {
 		return
 	}
 
-	//if event.InvolvedObject.FieldPath == "spec.container{%s}" {
-	//
-	//}
+	p.Logger.Tracef(
+		"handling %s event add event for %s: fieldPath=%v",
+		newEvent.Type, // Normal, Warning
+		p.TrackedPod,
+		newEvent.InvolvedObject.FieldPath,
+	)
 
-	p.Logger.Tracef("handling event add event for %s: %v", p.TrackedPod, newEvent)
+	p.inspectContainerEvent(newEvent)
 }
 
 // HandleEventUpdate is an UpdateFunc for cache.ResourceEventHandlerFuncs for Events.
@@ -180,7 +183,14 @@ func (p *podTracker) HandleEventUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	p.Logger.Tracef("handling event update event for %s: %v; %v", p.TrackedPod, oldEvent, newEvent)
+	p.Logger.Tracef(
+		"handling %s event update event for %s: fieldPath=%v",
+		newEvent.Type, // Normal, Warning
+		p.TrackedPod,
+		newEvent.InvolvedObject.FieldPath,
+	)
+
+	p.inspectContainerEvent(newEvent)
 }
 
 // HandleEventDelete is an DeleteFunc for cache.ResourceEventHandlerFuncs for Events.

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -176,7 +176,6 @@ func (p *podTracker) getTrackedPod(obj interface{}) *v1.Pod {
 
 // HandleEventAdd is an AddFunc for cache.ResourceEventHandlerFuncs for Events.
 func (p *podTracker) HandleEventAdd(newObj interface{}) {
-	// TODO: do something with the (possible) event
 	newEvent := p.getTrackedPodEvent(newObj)
 	if newEvent == nil {
 		// not valid or not for our tracked pod
@@ -195,7 +194,6 @@ func (p *podTracker) HandleEventAdd(newObj interface{}) {
 
 // HandleEventUpdate is an UpdateFunc for cache.ResourceEventHandlerFuncs for Events.
 func (p *podTracker) HandleEventUpdate(oldObj, newObj interface{}) {
-	// TODO: do something with the (possible) event(s)
 	oldEvent := p.getTrackedPodEvent(oldObj)
 	newEvent := p.getTrackedPodEvent(newObj)
 
@@ -217,7 +215,7 @@ func (p *podTracker) HandleEventUpdate(oldObj, newObj interface{}) {
 // HandleEventDelete is an DeleteFunc for cache.ResourceEventHandlerFuncs for Events.
 //func (p *podTracker) HandleEventDelete(oldObj interface{}) {
 //	oldEvent := p.getTrackedPodEvent(oldObj)
-//	if newEvent == nil {
+//	if oldEvent == nil {
 //		// not valid or not for our tracked pod
 //		return
 //	}

--- a/runtime/kubernetes/pod_tracker_test.go
+++ b/runtime/kubernetes/pod_tracker_test.go
@@ -470,3 +470,165 @@ func Test_podTracker_getTrackedPodEvent(t *testing.T) {
 		})
 	}
 }
+
+func Test_podTracker_HandleEventAdd(t *testing.T) {
+	// setup types
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	_podEvent := mockContainerEvent(
+		_pod,
+		"step-github-ooctocat-1-echo",
+		reasonInspectFailed,
+		"foobar",
+	)
+
+	_podTemplateEvent := _podEvent.DeepCopy()
+	_podTemplateEvent.InvolvedObject.Kind = new(v1.PodTemplate).TypeMeta.Kind
+
+	tests := []struct {
+		name       string
+		trackedPod string // namespace/podName
+		obj        interface{}
+	}{
+		{
+			name:       "got-tracked-pod-event",
+			trackedPod: "test/github-octocat-1",
+			obj:        _podEvent,
+		},
+		{
+			name:       "wrong-pod",
+			trackedPod: "test/github-octocat-2",
+			obj:        _podEvent,
+		},
+		{
+			name:       "invalid-type",
+			trackedPod: "test/github-octocat-1",
+			obj:        new(v1.PodTemplate),
+		},
+		{
+			name:       "nil",
+			trackedPod: "test/nil",
+			obj:        nil,
+		},
+		{
+			name:       "invalid-involved-object-type",
+			trackedPod: "test/github-octocat-1",
+			obj:        _podTemplateEvent,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := &podTracker{
+				Logger:     logger,
+				TrackedPod: test.trackedPod,
+				// other fields not used by getTrackedPodEvent
+				// if they're needed, use newPodTracker
+			}
+
+			// just make sure this doesn't panic
+			p.HandleEventAdd(test.obj)
+		})
+	}
+}
+
+func Test_podTracker_HandleEventUpdate(t *testing.T) {
+	// setup types
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	_podEvent := mockContainerEvent(
+		_pod,
+		"step-github-ooctocat-1-echo",
+		reasonBackOff,
+		"foobar",
+	)
+
+	_podTemplateEvent := _podEvent.DeepCopy()
+	_podTemplateEvent.InvolvedObject.Kind = new(v1.PodTemplate).TypeMeta.Kind
+
+	tests := []struct {
+		name       string
+		trackedPod string // namespace/podName
+		oldObj     interface{}
+		newObj     interface{}
+	}{
+		{
+			name:       "re-sync event without change",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     _podEvent,
+			newObj:     _podEvent,
+		},
+		{
+			name:       "wrong-pod",
+			trackedPod: "test/github-octocat-2",
+			oldObj:     _podEvent,
+			newObj:     _podEvent,
+		},
+		{
+			name:       "invalid-type-old",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     new(v1.PodTemplate),
+			newObj:     _podEvent,
+		},
+		{
+			name:       "nil-old",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     nil,
+			newObj:     _podEvent,
+		},
+		{
+			name:       "invalid-involved-object-type-old",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     _podTemplateEvent,
+			newObj:     _podEvent,
+		},
+		{
+			name:       "invalid-type-new",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     _podEvent,
+			newObj:     new(v1.PodTemplate),
+		},
+		{
+			name:       "nil-new",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     _podEvent,
+			newObj:     nil,
+		},
+		{
+			name:       "invalid-involved-object-type-new",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     _podEvent,
+			newObj:     _podTemplateEvent,
+		},
+		{
+			name:       "invalid-type-both",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     new(v1.PodTemplate),
+			newObj:     new(v1.PodTemplate),
+		},
+		{
+			name:       "nil-both",
+			trackedPod: "test/nil",
+			oldObj:     nil,
+			newObj:     nil,
+		},
+		{
+			name:       "invalid-involved-object-type-both",
+			trackedPod: "test/github-octocat-1",
+			oldObj:     _podTemplateEvent,
+			newObj:     _podTemplateEvent,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := &podTracker{
+				Logger:     logger,
+				TrackedPod: test.trackedPod,
+				// other fields not used by getTrackedPodEvent
+				// if they're needed, use newPodTracker
+			}
+
+			// just make sure this doesn't panic
+			p.HandleEventUpdate(test.oldObj, test.newObj)
+		})
+	}
+}


### PR DESCRIPTION
This is an alternate implementation of #279 using the `SharedInformer` infra to watch events introduced in #519.
Closes #279

## Overview

The Docker Runtime surfaces image pull errors naturally because of the blocking synchronous requests to pull an image or start a container.

The Kubernetes Runtime has to watch for events that show any errors with pulling images.

## `RunContainer` changes in k8s runtime

Wait until one of these conditions before returning:
- build canceled
- container is running
- got an image pull error

## `WaitContainer` changes in k8s runtime

Wait until one of these conditions before returning:
- build canceled (new)
- container is terminated (was already doing this)

## `containerTracker` additions

I added signal channels for `Running` and `ImagePulled`. I also added a channel for receiving image pull errors in `RunContainer`.

## `podTracker` changes

I need pod `Name` and `Namespace` in more places, so I copy those into the podTracker now.

I was surprised that the `SharedInformerFactory` I used to create the Informer/Lister for watching the build Pod did NOT work for watching events. Apparently, events don't get labeled, so I had to add a separate `eventInformerFactory` that uses a FieldSelector instead of a LabelSelector when making the list/watch API calls.

I did not rename `informerFactory` to `podInformerFactory` because it can easily be used for other k8s resources in the future (if needed), just not for Events.

I also added the Event event handler funcs (wow that was a mouth full - events about Events).

`podTracker.inspectContainerEvent()` (called by the Event event handlers) is responsible for
- sending the image pull events to `RunContainer`
- closing the `ImagePulled` signal channel when an event indicates that the pull was successful

I also adjusted `podTracker.inspectContainerStatuses()` so that it can also:
- surface image pull errors (in case the error is visible there, but not through the Events API - which is unlikely, but there doesn't seem to be any kind of guarantees about event availability, so this covers our bases)
- close the `Running` signal channel when the container status shows that it is running.

TODO:
- [x] merge #302
- [x] rebase
- [ ] write tests