### PR TITLE
bugfix(k8s): Drop TailContainer's logsContext to avoid early cancel

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -536,6 +536,7 @@ func (c *client) StreamBuild(ctx context.Context) error {
 				return nil
 			})
 		case <-ctx.Done():
+			c.Logger.Debug("streaming context canceled")
 			// build done or canceled
 			return nil
 		}

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -374,7 +374,7 @@ func (c *client) StreamBuild(ctx context.Context) error {
 		select {
 		case req := <-c.streamRequests:
 			streams.Go(func() error {
-				fmt.Fprintf(os.Stdout, "streaming %s container %s", req.Key, req.Container.ID)
+				fmt.Fprintf(os.Stdout, "[%s: %s] > Streaming container '%s'...\n", req.Key, req.Container.Name, req.Container.ID)
 
 				err := req.Stream(streamCtx, req.Container)
 				if err != nil {

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -232,10 +232,6 @@ func (c *client) setupContainerEnvironment(ctn *pipeline.Container) error {
 func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io.ReadCloser, error) {
 	c.Logger.Tracef("tailing output for container %s", ctn.ID)
 
-	// create a logsContext that will be canceled at the end of this
-	logsContext, logsDone := context.WithCancel(ctx)
-	defer logsDone()
-
 	// create object to store container logs
 	var logs io.ReadCloser
 
@@ -259,7 +255,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 		stream, err := c.Kubernetes.CoreV1().
 			Pods(c.config.Namespace).
 			GetLogs(c.Pod.ObjectMeta.Name, opts).
-			Stream(logsContext)
+			Stream(ctx)
 		if err != nil {
 			c.Logger.Errorf("%v", err)
 			return false, nil
@@ -303,7 +299,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 	// perform the function to capture logs with periodic backoff
 	//
 	// https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait?tab=doc#ExponentialBackoff
-	err := wait.ExponentialBackoffWithContext(logsContext, backoff, logsFunc)
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, logsFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -257,7 +257,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 			GetLogs(c.Pod.ObjectMeta.Name, opts).
 			Stream(ctx)
 		if err != nil {
-			c.Logger.Errorf("%v", err)
+			c.Logger.Errorf("error while requesting pod/logs stream for container %s: %v", ctn.ID, err)
 			return false, nil
 		}
 
@@ -301,6 +301,7 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 	// https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait?tab=doc#ExponentialBackoff
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, logsFunc)
 	if err != nil {
+		c.Logger.Errorf("exponential backoff error while tailing container %s: %v", ctn.ID, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Partially reverts #329 (see https://github.com/go-vela/worker/pull/329#discussion_r869658946).
In juggling all of my PRs, I thought I tested them merged together, but somehow I missed the breakage this caused.

We expect (at least part of) logsFunc to continue running after TailContainer returns.
Then StreamStep/StreamService/etc read from the returned ReadCloser until the end of the stream.

So, if the context gets canceled at the end of TailContainer (as introduced in #329), then the streaming is stopped before `Stream*` has read anything from it. So, log capture in the kubernetes runtime is currently broken for v0.14 😢 .

This fixes it by not creating+cancelling a new context in kubernetes TailContainer.

Also, I added/improved a log message about streaming output in each of the linux and local executors.