### PR TITLE
fix(runtime/k8s/build): lowercase pod name for build

### DIFF
--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -7,6 +7,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-vela/types/pipeline"
@@ -80,8 +81,8 @@ func (c *client) SetupBuild(ctx context.Context, b *pipeline.Build) error {
 	//
 	// https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1?tab=doc#ObjectMeta
 	c.Pod.ObjectMeta = metav1.ObjectMeta{
-		Name:        b.ID,
-		Namespace:   c.config.Namespace, // this is used by the podTracker
+		Name:        strings.ToLower(b.ID), // must be lowercase, see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+		Namespace:   c.config.Namespace,    // this is used by the podTracker
 		Labels:      labels,
 		Annotations: c.PipelinePodTemplate.Metadata.Annotations,
 	}

--- a/runtime/kubernetes/build_test.go
+++ b/runtime/kubernetes/build_test.go
@@ -319,6 +319,11 @@ func TestKubernetes_SetupBuild(t *testing.T) {
 				t.Errorf("Pod's pipeline label is %v, want %v", pipelineLabel, test.pipeline.ID)
 			}
 
+			// make sure that worker-defined name is lowercase for the Pod
+			if !reflect.DeepEqual(_engine.Pod.ObjectMeta.Name, "github-octocat-1") {
+				t.Errorf("Pod's ObjectMeta.Name is %v, want github-octocat-1", _engine.Pod.ObjectMeta.Name)
+			}
+
 			switch test.wantFromTemplate.(type) {
 			case velav1alpha1.PipelinePodTemplateMeta:
 				want := test.wantFromTemplate.(velav1alpha1.PipelinePodTemplateMeta)

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -160,7 +160,7 @@ var (
 
 	_stages = &pipeline.Build{
 		Version: "1",
-		ID:      "github-octocat-1",
+		ID:      "github-Octocat-1",
 		Services: pipeline.ContainerSlice{
 			{
 				ID:          "service-github-octocat-1-postgres",
@@ -224,7 +224,7 @@ var (
 
 	_steps = &pipeline.Build{
 		Version: "1",
-		ID:      "github-octocat-1",
+		ID:      "github-Octocat-1",
 		Services: pipeline.ContainerSlice{
 			{
 				ID:          "service-github-octocat-1-postgres",


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/679

Kubernetes does not like any uppercase in their pod names, which causes any build ran from a repo with an uppercase letter in its name or org to fail. 