### PR TITLE
refactor(executor tests): Make runtime a test arg

### DIFF
--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -191,7 +191,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		enforceTrustedRepos bool
 	}{
 		{
-			name:                "enforce trusted repos enabled: privileged steps pipeline with trusted repo",
+			name:                "docker-enforce trusted repos enabled: privileged steps pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -201,7 +201,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged steps pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos enabled: privileged steps pipeline with untrusted repo",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -211,7 +211,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged steps pipeline with trusted repo",
+			name:                "docker-enforce trusted repos enabled: non-privileged steps pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -221,7 +221,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -231,7 +231,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged steps pipeline with trusted repo",
+			name:                "docker-enforce trusted repos disabled: privileged steps pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -241,7 +241,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged steps pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos disabled: privileged steps pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -251,7 +251,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged steps pipeline with trusted repo",
+			name:                "docker-enforce trusted repos disabled: non-privileged steps pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -261,7 +261,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -271,7 +271,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged steps pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: privileged steps pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -281,7 +281,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged steps pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: privileged steps pipeline with untrusted repo and dynamic image:tag",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -291,7 +291,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged steps pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: non-privileged steps pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -301,7 +301,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -311,7 +311,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged steps pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: privileged steps pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -321,7 +321,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged steps pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: privileged steps pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -331,7 +331,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged steps pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: non-privileged steps pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -341,7 +341,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -351,7 +351,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged services pipeline with trusted repo",
+			name:                "docker-enforce trusted repos enabled: privileged services pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -361,7 +361,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged services pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos enabled: privileged services pipeline with untrusted repo",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -371,7 +371,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged services pipeline with trusted repo",
+			name:                "docker-enforce trusted repos enabled: non-privileged services pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -381,7 +381,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged services pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos enabled: non-privileged services pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -391,7 +391,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged services pipeline with trusted repo",
+			name:                "docker-enforce trusted repos disabled: privileged services pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -401,7 +401,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged services pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos disabled: privileged services pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -411,7 +411,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged services pipeline with trusted repo",
+			name:                "docker-enforce trusted repos disabled: non-privileged services pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -421,7 +421,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged services pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos disabled: non-privileged services pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -431,7 +431,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged services pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: privileged services pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -441,7 +441,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged services pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: privileged services pipeline with untrusted repo and dynamic image:tag",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -451,7 +451,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged services pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: non-privileged services pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -461,7 +461,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged services pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: non-privileged services pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -471,27 +471,27 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged services pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: privileged services pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
-			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
-			privilegedImages:    _privilegedImagesServicesPipeline, // this matches the image from test.pipeline
-			enforceTrustedRepos: false,
-		},
-		{
-			name:                "enforce trusted repos disabled: privileged services pipeline with untrusted repo and dynamic image:tag",
-			failure:             false,
-			runtime:             constants.DriverDocker,
-			build:               _buildWithMessageAlpine,
-			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
 			privilegedImages:    _privilegedImagesServicesPipeline, // this matches the image from test.pipeline
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged services pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: privileged services pipeline with untrusted repo and dynamic image:tag",
+			failure:             false,
+			runtime:             constants.DriverDocker,
+			build:               _buildWithMessageAlpine,
+			repo:                _untrustedRepo,
+			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
+			privilegedImages:    _privilegedImagesServicesPipeline, // this matches the image from test.pipeline
+			enforceTrustedRepos: false,
+		},
+		{
+			name:                "docker-enforce trusted repos disabled: non-privileged services pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -501,7 +501,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged services pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: non-privileged services pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -511,7 +511,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged stages pipeline with trusted repo",
+			name:                "docker-enforce trusted repos enabled: privileged stages pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -521,7 +521,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged stages pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos enabled: privileged stages pipeline with untrusted repo",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -531,7 +531,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged stages pipeline with trusted repo",
+			name:                "docker-enforce trusted repos enabled: non-privileged stages pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -541,7 +541,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -551,7 +551,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged stages pipeline with trusted repo",
+			name:                "docker-enforce trusted repos disabled: privileged stages pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -561,7 +561,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged stages pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos disabled: privileged stages pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -571,7 +571,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged stages pipeline with trusted repo",
+			name:                "docker-enforce trusted repos disabled: non-privileged stages pipeline with trusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -581,7 +581,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo",
+			name:                "docker-enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -591,7 +591,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged stages pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: privileged stages pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -601,7 +601,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged stages pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: privileged stages pipeline with untrusted repo and dynamic image:tag",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -611,7 +611,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged stages pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: non-privileged stages pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -621,7 +621,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -631,7 +631,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged stages pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: privileged stages pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -641,7 +641,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged stages pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: privileged stages pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -651,7 +651,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged stages pipeline with trusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: non-privileged stages pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -661,7 +661,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo and dynamic image:tag",
+			name:                "docker-enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
@@ -671,7 +671,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged steps pipeline with trusted repo and init step name",
+			name:                "docker-enforce trusted repos enabled: privileged steps pipeline with trusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -681,7 +681,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged steps pipeline with untrusted repo and init step name",
+			name:                "docker-enforce trusted repos enabled: privileged steps pipeline with untrusted repo and init step name",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -691,7 +691,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged steps pipeline with trusted repo and init step name",
+			name:                "docker-enforce trusted repos enabled: non-privileged steps pipeline with trusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -701,7 +701,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo and init step name",
+			name:                "docker-enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo and init step name",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -711,7 +711,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged steps pipeline with trusted repo and init step name",
+			name:                "docker-enforce trusted repos disabled: privileged steps pipeline with trusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -721,7 +721,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged steps pipeline with untrusted repo and init step name",
+			name:                "docker-enforce trusted repos disabled: privileged steps pipeline with untrusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -731,7 +731,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged steps pipeline with trusted repo and init step name",
+			name:                "docker-enforce trusted repos disabled: non-privileged steps pipeline with trusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -741,7 +741,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo and init step name",
+			name:                "docker-enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -751,7 +751,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged stages pipeline with trusted repo and init step name",
+			name:                "docker-enforce trusted repos enabled: privileged stages pipeline with trusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -761,7 +761,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged stages pipeline with untrusted repo and init step name",
+			name:                "docker-enforce trusted repos enabled: privileged stages pipeline with untrusted repo and init step name",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -771,7 +771,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged stages pipeline with trusted repo and init step name",
+			name:                "docker-enforce trusted repos enabled: non-privileged stages pipeline with trusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -781,7 +781,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo and init step name",
+			name:                "docker-enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo and init step name",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -791,7 +791,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged stages pipeline with trusted repo and init step name",
+			name:                "docker-enforce trusted repos disabled: privileged stages pipeline with trusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -801,7 +801,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged stages pipeline with untrusted repo and init step name",
+			name:                "docker-enforce trusted repos disabled: privileged stages pipeline with untrusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -811,7 +811,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged stages pipeline with trusted repo and init step name",
+			name:                "docker-enforce trusted repos disabled: non-privileged stages pipeline with trusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -821,7 +821,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo and init step name",
+			name:                "docker-enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo and init step name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -831,7 +831,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged services pipeline with trusted repo and init service name",
+			name:                "docker-enforce trusted repos enabled: privileged services pipeline with trusted repo and init service name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -841,7 +841,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: privileged services pipeline with untrusted repo and init service name",
+			name:                "docker-enforce trusted repos enabled: privileged services pipeline with untrusted repo and init service name",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -851,7 +851,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged services pipeline with trusted repo and init service name",
+			name:                "docker-enforce trusted repos enabled: non-privileged services pipeline with trusted repo and init service name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -861,7 +861,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos enabled: non-privileged services pipeline with untrusted repo and init service name",
+			name:                "docker-enforce trusted repos enabled: non-privileged services pipeline with untrusted repo and init service name",
 			failure:             true,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -871,7 +871,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: true,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged services pipeline with trusted repo and init service name",
+			name:                "docker-enforce trusted repos disabled: privileged services pipeline with trusted repo and init service name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -881,7 +881,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: privileged services pipeline with untrusted repo and init service name",
+			name:                "docker-enforce trusted repos disabled: privileged services pipeline with untrusted repo and init service name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -891,7 +891,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged services pipeline with trusted repo and init service name",
+			name:                "docker-enforce trusted repos disabled: non-privileged services pipeline with trusted repo and init service name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,
@@ -901,7 +901,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 			enforceTrustedRepos: false,
 		},
 		{
-			name:                "enforce trusted repos disabled: non-privileged services pipeline with untrusted repo and init service name",
+			name:                "docker-enforce trusted repos disabled: non-privileged services pipeline with untrusted repo and init service name",
 			failure:             false,
 			runtime:             constants.DriverDocker,
 			build:               _build,

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/go-vela/worker/internal/message"
+	"github.com/go-vela/worker/runtime"
 	"github.com/go-vela/worker/runtime/docker"
 
 	"github.com/go-vela/sdk-go/vela"

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -175,11 +175,6 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
-	if err != nil {
-		t.Errorf("unable to create runtime engine: %v", err)
-	}
-
 	tests := []struct {
 		name                string
 		failure             bool
@@ -926,6 +921,16 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
 
+			var _runtime runtime.Engine
+
+			switch test.runtime {
+			case constants.DriverDocker:
+				_runtime, err = docker.NewMock()
+				if err != nil {
+					t.Errorf("unable to create docker runtime engine: %v", err)
+				}
+			}
+
 			_engine, err := New(
 				WithBuild(test.build),
 				WithPipeline(_pipeline),
@@ -984,11 +989,6 @@ func TestLinux_PlanBuild(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
-	if err != nil {
-		t.Errorf("unable to create docker runtime engine: %v", err)
-	}
-
 	tests := []struct {
 		name     string
 		failure  bool
@@ -1033,6 +1033,16 @@ func TestLinux_PlanBuild(t *testing.T) {
 				Compile(test.pipeline)
 			if err != nil {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
+			}
+
+			var _runtime runtime.Engine
+
+			switch test.runtime {
+			case constants.DriverDocker:
+				_runtime, err = docker.NewMock()
+				if err != nil {
+					t.Errorf("unable to create docker runtime engine: %v", err)
+				}
 			}
 
 			_engine, err := New(
@@ -1086,11 +1096,6 @@ func TestLinux_AssembleBuild(t *testing.T) {
 	_client, err := vela.NewClient(s.URL, "", nil)
 	if err != nil {
 		t.Errorf("unable to create Vela API client: %v", err)
-	}
-
-	_runtime, err := docker.NewMock()
-	if err != nil {
-		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
 
 	streamRequests, done := message.MockStreamRequestsWithCancel(context.Background())
@@ -1190,6 +1195,16 @@ func TestLinux_AssembleBuild(t *testing.T) {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
 			}
 
+			var _runtime runtime.Engine
+
+			switch test.runtime {
+			case constants.DriverDocker:
+				_runtime, err = docker.NewMock()
+				if err != nil {
+					t.Errorf("unable to create docker runtime engine: %v", err)
+				}
+			}
+
 			_engine, err := New(
 				WithBuild(_build),
 				WithPipeline(_pipeline),
@@ -1242,11 +1257,6 @@ func TestLinux_ExecBuild(t *testing.T) {
 	_client, err := vela.NewClient(s.URL, "", nil)
 	if err != nil {
 		t.Errorf("unable to create Vela API client: %v", err)
-	}
-
-	_runtime, err := docker.NewMock()
-	if err != nil {
-		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
 
 	tests := []struct {
@@ -1305,6 +1315,16 @@ func TestLinux_ExecBuild(t *testing.T) {
 				Compile(test.pipeline)
 			if err != nil {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
+			}
+
+			var _runtime runtime.Engine
+
+			switch test.runtime {
+			case constants.DriverDocker:
+				_runtime, err = docker.NewMock()
+				if err != nil {
+					t.Errorf("unable to create docker runtime engine: %v", err)
+				}
 			}
 
 			streamRequests, done := message.MockStreamRequestsWithCancel(context.Background())
@@ -1396,11 +1416,6 @@ func TestLinux_StreamBuild(t *testing.T) {
 	_client, err := vela.NewClient(s.URL, "", nil)
 	if err != nil {
 		t.Errorf("unable to create Vela API client: %v", err)
-	}
-
-	_runtime, err := docker.NewMock()
-	if err != nil {
-		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
 
 	type planFuncType = func(context.Context, *pipeline.Container) error
@@ -1647,6 +1662,16 @@ func TestLinux_StreamBuild(t *testing.T) {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
 			}
 
+			var _runtime runtime.Engine
+
+			switch test.runtime {
+			case constants.DriverDocker:
+				_runtime, err = docker.NewMock()
+				if err != nil {
+					t.Errorf("unable to create docker runtime engine: %v", err)
+				}
+			}
+
 			_engine, err := New(
 				WithBuild(_build),
 				WithPipeline(_pipeline),
@@ -1739,11 +1764,6 @@ func TestLinux_DestroyBuild(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
-	if err != nil {
-		t.Errorf("unable to create docker runtime engine: %v", err)
-	}
-
 	tests := []struct {
 		name     string
 		failure  bool
@@ -1812,6 +1832,16 @@ func TestLinux_DestroyBuild(t *testing.T) {
 				Compile(test.pipeline)
 			if err != nil {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
+			}
+
+			var _runtime runtime.Engine
+
+			switch test.runtime {
+			case constants.DriverDocker:
+				_runtime, err = docker.NewMock()
+				if err != nil {
+					t.Errorf("unable to create docker runtime engine: %v", err)
+				}
 			}
 
 			_engine, err := New(

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1582,6 +1582,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 			name:          "docker-early exit from ExecBuild",
 			failure:       false,
 			earlyExecExit: true,
+			runtime:       constants.DriverDocker,
 			pipeline:      "testdata/build/steps/basic.yml",
 			messageKey:    "step",
 			streamFunc: func(c *client) message.StreamFunc {
@@ -1604,6 +1605,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 			name:           "docker-build complete before ExecBuild called",
 			failure:        false,
 			earlyBuildDone: true,
+			runtime:        constants.DriverDocker,
 			pipeline:       "testdata/build/steps/basic.yml",
 			messageKey:     "step",
 			streamFunc: func(c *client) message.StreamFunc {
@@ -1626,6 +1628,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 			name:          "docker-early exit from ExecBuild and build complete signaled",
 			failure:       false,
 			earlyExecExit: true,
+			runtime:       constants.DriverDocker,
 			pipeline:      "testdata/build/steps/basic.yml",
 			messageKey:    "step",
 			streamFunc: func(c *client) message.StreamFunc {

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -183,6 +183,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 	tests := []struct {
 		name                string
 		failure             bool
+		runtime             string
 		build               *library.Build
 		repo                *library.Repo
 		pipeline            string
@@ -192,6 +193,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged steps pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/basic.yml",
@@ -201,6 +203,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged steps pipeline with untrusted repo",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/basic.yml",
@@ -210,6 +213,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged steps pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/basic.yml",
@@ -219,6 +223,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/basic.yml",
@@ -228,6 +233,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged steps pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/basic.yml",
@@ -237,6 +243,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged steps pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/basic.yml",
@@ -246,6 +253,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged steps pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/basic.yml",
@@ -255,6 +263,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/basic.yml",
@@ -264,6 +273,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged steps pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/img_environmentdynamic.yml",
@@ -273,6 +283,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged steps pipeline with untrusted repo and dynamic image:tag",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/img_environmentdynamic.yml",
@@ -282,6 +293,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged steps pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/img_environmentdynamic.yml",
@@ -291,6 +303,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/img_environmentdynamic.yml",
@@ -300,6 +313,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged steps pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/img_environmentdynamic.yml",
@@ -309,6 +323,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged steps pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/img_environmentdynamic.yml",
@@ -318,6 +333,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged steps pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/img_environmentdynamic.yml",
@@ -327,6 +343,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/img_environmentdynamic.yml",
@@ -336,6 +353,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged services pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/basic.yml",
@@ -345,6 +363,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged services pipeline with untrusted repo",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/basic.yml",
@@ -354,6 +373,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged services pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/basic.yml",
@@ -363,6 +383,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged services pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/basic.yml",
@@ -372,6 +393,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged services pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/basic.yml",
@@ -381,6 +403,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged services pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/basic.yml",
@@ -390,6 +413,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged services pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/basic.yml",
@@ -399,6 +423,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged services pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/basic.yml",
@@ -408,6 +433,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged services pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
@@ -417,6 +443,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged services pipeline with untrusted repo and dynamic image:tag",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
@@ -426,6 +453,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged services pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
@@ -435,6 +463,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged services pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
@@ -444,6 +473,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged services pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
@@ -453,6 +483,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged services pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
@@ -462,6 +493,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged services pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
@@ -471,6 +503,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged services pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/img_environmentdynamic.yml",
@@ -480,6 +513,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged stages pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/basic.yml",
@@ -489,6 +523,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged stages pipeline with untrusted repo",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/basic.yml",
@@ -498,6 +533,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged stages pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/basic.yml",
@@ -507,6 +543,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/basic.yml",
@@ -516,6 +553,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged stages pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/basic.yml",
@@ -525,6 +563,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged stages pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/basic.yml",
@@ -534,6 +573,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged stages pipeline with trusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/basic.yml",
@@ -543,6 +583,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/basic.yml",
@@ -552,6 +593,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged stages pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/img_environmentdynamic.yml",
@@ -561,6 +603,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged stages pipeline with untrusted repo and dynamic image:tag",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/img_environmentdynamic.yml",
@@ -570,6 +613,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged stages pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/img_environmentdynamic.yml",
@@ -579,6 +623,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/img_environmentdynamic.yml",
@@ -588,6 +633,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged stages pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/img_environmentdynamic.yml",
@@ -597,6 +643,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged stages pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/img_environmentdynamic.yml",
@@ -606,6 +653,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged stages pipeline with trusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/img_environmentdynamic.yml",
@@ -615,6 +663,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo and dynamic image:tag",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _buildWithMessageAlpine,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/img_environmentdynamic.yml",
@@ -624,6 +673,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged steps pipeline with trusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/name_init.yml",
@@ -633,6 +683,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged steps pipeline with untrusted repo and init step name",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/name_init.yml",
@@ -642,6 +693,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged steps pipeline with trusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/name_init.yml",
@@ -651,6 +703,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged steps pipeline with untrusted repo and init step name",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/name_init.yml",
@@ -660,6 +713,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged steps pipeline with trusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/name_init.yml",
@@ -669,6 +723,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged steps pipeline with untrusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/name_init.yml",
@@ -678,6 +733,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged steps pipeline with trusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/steps/name_init.yml",
@@ -687,6 +743,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged steps pipeline with untrusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/steps/name_init.yml",
@@ -696,6 +753,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged stages pipeline with trusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/name_init.yml",
@@ -705,6 +763,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged stages pipeline with untrusted repo and init step name",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/name_init.yml",
@@ -714,6 +773,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged stages pipeline with trusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/name_init.yml",
@@ -723,6 +783,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged stages pipeline with untrusted repo and init step name",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/name_init.yml",
@@ -732,6 +793,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged stages pipeline with trusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/name_init.yml",
@@ -741,6 +803,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged stages pipeline with untrusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/name_init.yml",
@@ -750,6 +813,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged stages pipeline with trusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/stages/name_init.yml",
@@ -759,6 +823,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged stages pipeline with untrusted repo and init step name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/stages/name_init.yml",
@@ -768,6 +833,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged services pipeline with trusted repo and init service name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/name_init.yml",
@@ -777,6 +843,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: privileged services pipeline with untrusted repo and init service name",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/name_init.yml",
@@ -786,6 +853,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged services pipeline with trusted repo and init service name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/name_init.yml",
@@ -795,6 +863,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos enabled: non-privileged services pipeline with untrusted repo and init service name",
 			failure:             true,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/name_init.yml",
@@ -804,6 +873,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged services pipeline with trusted repo and init service name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/name_init.yml",
@@ -813,6 +883,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: privileged services pipeline with untrusted repo and init service name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/name_init.yml",
@@ -822,6 +893,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged services pipeline with trusted repo and init service name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _trustedRepo,
 			pipeline:            "testdata/build/services/name_init.yml",
@@ -831,6 +903,7 @@ func TestLinux_AssembleBuild_EnforceTrustedRepos(t *testing.T) {
 		{
 			name:                "enforce trusted repos disabled: non-privileged services pipeline with untrusted repo and init service name",
 			failure:             false,
+			runtime:             constants.DriverDocker,
 			build:               _build,
 			repo:                _untrustedRepo,
 			pipeline:            "testdata/build/services/name_init.yml",
@@ -919,26 +992,31 @@ func TestLinux_PlanBuild(t *testing.T) {
 	tests := []struct {
 		name     string
 		failure  bool
+		runtime  string
 		pipeline string
 	}{
 		{
 			name:     "docker-basic secrets pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
 		{
 			name:     "docker-basic services pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/services/basic.yml",
 		},
 		{
 			name:     "docker-basic steps pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
 		{
 			name:     "docker-basic stages pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
 	}
@@ -1021,66 +1099,79 @@ func TestLinux_AssembleBuild(t *testing.T) {
 	tests := []struct {
 		name     string
 		failure  bool
+		runtime  string
 		pipeline string
 	}{
 		{
 			name:     "docker-basic secrets pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
 		{
 			name:     "docker-secrets pipeline with image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/secrets/img_notfound.yml",
 		},
 		{
 			name:     "docker-secrets pipeline with ignoring image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/secrets/img_ignorenotfound.yml",
 		},
 		{
 			name:     "docker-basic services pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/services/basic.yml",
 		},
 		{
 			name:     "docker-services pipeline with image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/services/img_notfound.yml",
 		},
 		{
 			name:     "docker-services pipeline with ignoring image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/services/img_ignorenotfound.yml",
 		},
 		{
 			name:     "docker-basic steps pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
 		{
 			name:     "docker-steps pipeline with image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/img_notfound.yml",
 		},
 		{
 			name:     "docker-steps pipeline with ignoring image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/img_ignorenotfound.yml",
 		},
 		{
 			name:     "docker-basic stages pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
 		{
 			name:     "docker-stages pipeline with image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/stages/img_notfound.yml",
 		},
 		{
 			name:     "docker-stages pipeline with ignoring image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/stages/img_ignorenotfound.yml",
 		},
 	}
@@ -1161,36 +1252,43 @@ func TestLinux_ExecBuild(t *testing.T) {
 	tests := []struct {
 		name     string
 		failure  bool
+		runtime  string
 		pipeline string
 	}{
 		{
 			name:     "docker-basic services pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/services/basic.yml",
 		},
 		{
 			name:     "docker-services pipeline with image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/services/img_notfound.yml",
 		},
 		{
 			name:     "docker-basic steps pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
 		{
 			name:     "docker-steps pipeline with image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/img_notfound.yml",
 		},
 		{
 			name:     "docker-basic stages pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
 		{
 			name:     "docker-stages pipeline with image not found",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/stages/img_notfound.yml",
 		},
 	}
@@ -1315,6 +1413,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 	tests := []struct {
 		name           string
 		failure        bool
+		runtime        string
 		earlyExecExit  bool
 		earlyBuildDone bool
 		pipeline       string
@@ -1327,6 +1426,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 		{
 			name:       "docker-basic services pipeline",
 			failure:    false,
+			runtime:    constants.DriverDocker,
 			pipeline:   "testdata/build/services/basic.yml",
 			messageKey: "service",
 			streamFunc: func(c *client) message.StreamFunc {
@@ -1350,6 +1450,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 		{
 			name:       "docker-basic services pipeline with StreamService failure",
 			failure:    false,
+			runtime:    constants.DriverDocker,
 			pipeline:   "testdata/build/services/basic.yml",
 			messageKey: "service",
 			streamFunc: func(c *client) message.StreamFunc {
@@ -1374,6 +1475,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 		{
 			name:       "docker-basic steps pipeline",
 			failure:    false,
+			runtime:    constants.DriverDocker,
 			pipeline:   "testdata/build/steps/basic.yml",
 			messageKey: "step",
 			streamFunc: func(c *client) message.StreamFunc {
@@ -1395,6 +1497,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 		{
 			name:       "docker-basic steps pipeline with StreamStep failure",
 			failure:    false,
+			runtime:    constants.DriverDocker,
 			pipeline:   "testdata/build/steps/basic.yml",
 			messageKey: "step",
 			streamFunc: func(c *client) message.StreamFunc {
@@ -1417,6 +1520,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 		{
 			name:       "docker-basic stages pipeline",
 			failure:    false,
+			runtime:    constants.DriverDocker,
 			pipeline:   "testdata/build/stages/basic.yml",
 			messageKey: "step",
 			streamFunc: func(c *client) message.StreamFunc {
@@ -1438,6 +1542,7 @@ func TestLinux_StreamBuild(t *testing.T) {
 		{
 			name:       "docker-basic secrets pipeline",
 			failure:    false,
+			runtime:    constants.DriverDocker,
 			pipeline:   "testdata/build/secrets/basic.yml",
 			messageKey: "secret",
 			streamFunc: func(c *client) message.StreamFunc {
@@ -1642,46 +1747,55 @@ func TestLinux_DestroyBuild(t *testing.T) {
 	tests := []struct {
 		name     string
 		failure  bool
+		runtime  string
 		pipeline string
 	}{
 		{
 			name:     "docker-basic secrets pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
 		{
 			name:     "docker-secrets pipeline with name not found",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/secrets/name_notfound.yml",
 		},
 		{
 			name:     "docker-basic services pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/services/basic.yml",
 		},
 		{
 			name:     "docker-services pipeline with name not found",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/services/name_notfound.yml",
 		},
 		{
 			name:     "docker-basic steps pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
 		{
 			name:     "docker-steps pipeline with name not found",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/name_notfound.yml",
 		},
 		{
 			name:     "docker-basic stages pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
 		{
 			name:     "docker-stages pipeline with name not found",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/stages/name_notfound.yml",
 		},
 	}

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-vela/sdk-go/vela"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
 
@@ -44,44 +45,45 @@ func TestLinux_CreateBuild(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
-	if err != nil {
-		t.Errorf("unable to create docker runtime engine: %v", err)
-	}
-
 	tests := []struct {
 		name     string
 		failure  bool
+		runtime  string
 		build    *library.Build
 		pipeline string
 	}{
 		{
 			name:     "docker-basic secrets pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			build:    _build,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
 		{
 			name:     "docker-basic services pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			build:    _build,
 			pipeline: "testdata/build/services/basic.yml",
 		},
 		{
 			name:     "docker-basic steps pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			build:    _build,
 			pipeline: "testdata/build/steps/basic.yml",
 		},
 		{
 			name:     "docker-basic stages pipeline",
 			failure:  false,
+			runtime:  constants.DriverDocker,
 			build:    _build,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
 		{
 			name:     "docker-steps pipeline with empty build",
 			failure:  true,
+			runtime:  constants.DriverDocker,
 			build:    new(library.Build),
 			pipeline: "testdata/build/steps/basic.yml",
 		},
@@ -99,6 +101,16 @@ func TestLinux_CreateBuild(t *testing.T) {
 				Compile(test.pipeline)
 			if err != nil {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
+			}
+
+			var _runtime runtime.Engine
+
+			switch test.runtime {
+			case constants.DriverDocker:
+				_runtime, err = docker.NewMock()
+				if err != nil {
+					t.Errorf("unable to create docker runtime engine: %v", err)
+				}
 			}
 
 			_engine, err := New(

--- a/executor/linux/opts_test.go
+++ b/executor/linux/opts_test.go
@@ -480,7 +480,7 @@ func TestLinux_Opt_WithRepo(t *testing.T) {
 
 func TestLinux_Opt_WithRuntime(t *testing.T) {
 	// setup types
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -494,7 +494,7 @@ func TestLinux_Opt_WithRuntime(t *testing.T) {
 		{
 			name:    "docker runtime",
 			failure: false,
-			runtime: _runtime,
+			runtime: _docker,
 		},
 		{
 			name:    "nil runtime",
@@ -522,8 +522,8 @@ func TestLinux_Opt_WithRuntime(t *testing.T) {
 				t.Errorf("WithRuntime returned err: %v", err)
 			}
 
-			if !reflect.DeepEqual(_engine.Runtime, _runtime) {
-				t.Errorf("WithRuntime is %v, want %v", _engine.Runtime, _runtime)
+			if !reflect.DeepEqual(_engine.Runtime, test.runtime) {
+				t.Errorf("WithRuntime is %v, want %v", _engine.Runtime, test.runtime)
 			}
 		})
 	}

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-vela/server/mock/server"
 
 	"github.com/go-vela/worker/internal/message"
+	"github.com/go-vela/worker/runtime"
 	"github.com/go-vela/worker/runtime/docker"
 
 	"github.com/go-vela/sdk-go/vela"
@@ -45,7 +46,7 @@ func TestLinux_Secret_create(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -54,11 +55,13 @@ func TestLinux_Secret_create(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-good image tag",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_vault",
 				Directory:   "/vela/src/vcs.company.com/github/octocat",
@@ -72,6 +75,7 @@ func TestLinux_Secret_create(t *testing.T) {
 		{
 			name:    "docker-notfound image tag",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_vault",
 				Directory:   "/vela/src/vcs.company.com/github/octocat",
@@ -91,7 +95,7 @@ func TestLinux_Secret_create(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(_steps),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)
@@ -132,7 +136,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -146,12 +150,14 @@ func TestLinux_Secret_delete(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 		step      *library.Step
 	}{
 		{
 			name:    "docker-running container-empty step",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_vault",
 				Directory:   "/vela/src/vcs.company.com/github/octocat",
@@ -166,6 +172,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 		{
 			name:    "docker-running container-pending step",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_vault",
 				Directory:   "/vela/src/vcs.company.com/github/octocat",
@@ -180,6 +187,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 		{
 			name:    "docker-inspecting container failure due to invalid container id",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_notfound",
 				Directory:   "/vela/src/vcs.company.com/github/octocat",
@@ -194,6 +202,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 		{
 			name:    "docker-removing container failure",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_ignorenotfound",
 				Directory:   "/vela/src/vcs.company.com/github/octocat",
@@ -214,7 +223,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(_steps),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)
@@ -261,7 +270,7 @@ func TestLinux_Secret_exec(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -273,16 +282,19 @@ func TestLinux_Secret_exec(t *testing.T) {
 	tests := []struct {
 		name     string
 		failure  bool
+		runtime  runtime.Engine
 		pipeline string
 	}{
 		{
 			name:     "docker-basic secrets pipeline",
 			failure:  false,
+			runtime:  _docker,
 			pipeline: "testdata/build/secrets/basic.yml",
 		},
 		{
 			name:     "docker-pipeline with secret name not found",
 			failure:  true,
+			runtime:  _docker,
 			pipeline: "testdata/build/secrets/name_notfound.yml",
 		},
 	}
@@ -307,7 +319,7 @@ func TestLinux_Secret_exec(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(p),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 				withStreamRequests(streamRequests),
@@ -353,7 +365,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -362,11 +374,13 @@ func TestLinux_Secret_pull(t *testing.T) {
 	tests := []struct {
 		name    string
 		failure bool
+		runtime runtime.Engine
 		secret  *pipeline.Secret
 	}{
 		{
 			name:    "docker-success with org secret",
 			failure: false,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -379,6 +393,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		{
 			name:    "docker-failure with invalid org secret",
 			failure: true,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -391,6 +406,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		{
 			name:    "docker-failure with org secret key not found",
 			failure: true,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -403,6 +419,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		{
 			name:    "docker-success with repo secret",
 			failure: false,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -415,6 +432,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		{
 			name:    "docker-failure with invalid repo secret",
 			failure: true,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -427,6 +445,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		{
 			name:    "docker-failure with repo secret key not found",
 			failure: true,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -439,6 +458,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		{
 			name:    "docker-success with shared secret",
 			failure: false,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -451,6 +471,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		{
 			name:    "docker-failure with shared secret key not found",
 			failure: true,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -463,6 +484,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		{
 			name:    "docker-failure with invalid type",
 			failure: true,
+			runtime: _docker,
 			secret: &pipeline.Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -481,7 +503,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(testSteps()),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)
@@ -522,7 +544,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -531,12 +553,14 @@ func TestLinux_Secret_stream(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		logs      *library.Log
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-container step succeeds",
 			failure: false,
+			runtime: _docker,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -551,6 +575,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 		{
 			name:    "docker-container step fails because of invalid container id",
 			failure: true,
+			runtime: _docker,
 			logs:    new(library.Log),
 			container: &pipeline.Container{
 				ID:          "secret_github_octocat_1_notfound",
@@ -571,7 +596,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(_steps),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)

--- a/executor/linux/service_test.go
+++ b/executor/linux/service_test.go
@@ -133,7 +133,7 @@ func TestLinux_PlanService(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -143,10 +143,12 @@ func TestLinux_PlanService(t *testing.T) {
 		name      string
 		failure   bool
 		container *pipeline.Container
+		runtime   runtime.Engine
 	}{
 		{
 			name:    "docker-basic service container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
 				Detach:      true,
@@ -162,6 +164,7 @@ func TestLinux_PlanService(t *testing.T) {
 		{
 			name:    "docker-service container with nil environment",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
 				Detach:      true,
@@ -177,6 +180,7 @@ func TestLinux_PlanService(t *testing.T) {
 		{
 			name:      "docker-empty service container",
 			failure:   true,
+			runtime:   _docker,
 			container: new(pipeline.Container),
 		},
 	}
@@ -188,7 +192,7 @@ func TestLinux_PlanService(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(new(pipeline.Build)),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)
@@ -228,7 +232,7 @@ func TestLinux_ExecService(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -240,11 +244,13 @@ func TestLinux_ExecService(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-basic service container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
 				Detach:      true,
@@ -260,6 +266,7 @@ func TestLinux_ExecService(t *testing.T) {
 		{
 			name:    "docker-service container with image not found",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
 				Detach:      true,
@@ -275,6 +282,7 @@ func TestLinux_ExecService(t *testing.T) {
 		{
 			name:      "docker-empty service container",
 			failure:   true,
+			runtime:   _docker,
 			container: new(pipeline.Container),
 		},
 	}
@@ -286,7 +294,7 @@ func TestLinux_ExecService(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(new(pipeline.Build)),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 				withStreamRequests(streamRequests),
@@ -332,7 +340,7 @@ func TestLinux_StreamService(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -341,11 +349,13 @@ func TestLinux_StreamService(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-basic service container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
 				Detach:      true,
@@ -361,6 +371,7 @@ func TestLinux_StreamService(t *testing.T) {
 		{
 			name:    "docker-service container with name not found",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_notfound",
 				Detach:      true,
@@ -376,6 +387,7 @@ func TestLinux_StreamService(t *testing.T) {
 		{
 			name:      "docker-empty service container",
 			failure:   true,
+			runtime:   _docker,
 			container: new(pipeline.Container),
 		},
 	}
@@ -387,7 +399,7 @@ func TestLinux_StreamService(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(new(pipeline.Build)),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)
@@ -432,7 +444,7 @@ func TestLinux_DestroyService(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -441,11 +453,13 @@ func TestLinux_DestroyService(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-basic service container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_postgres",
 				Detach:      true,
@@ -461,6 +475,7 @@ func TestLinux_DestroyService(t *testing.T) {
 		{
 			name:    "docker-service container with ignoring name not found",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "service_github_octocat_1_ignorenotfound",
 				Detach:      true,
@@ -482,7 +497,7 @@ func TestLinux_DestroyService(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(new(pipeline.Build)),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)

--- a/executor/linux/step_test.go
+++ b/executor/linux/step_test.go
@@ -145,7 +145,7 @@ func TestLinux_PlanStep(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -154,11 +154,13 @@ func TestLinux_PlanStep(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-basic step container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -172,6 +174,7 @@ func TestLinux_PlanStep(t *testing.T) {
 		{
 			name:    "docker-step container with nil environment",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -185,6 +188,7 @@ func TestLinux_PlanStep(t *testing.T) {
 		{
 			name:      "docker-empty step container",
 			failure:   true,
+			runtime:   _docker,
 			container: new(pipeline.Container),
 		},
 	}
@@ -196,7 +200,7 @@ func TestLinux_PlanStep(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(new(pipeline.Build)),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)
@@ -236,7 +240,7 @@ func TestLinux_ExecStep(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -248,11 +252,13 @@ func TestLinux_ExecStep(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-init step container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -266,6 +272,7 @@ func TestLinux_ExecStep(t *testing.T) {
 		{
 			name:    "docker-basic step container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -279,6 +286,7 @@ func TestLinux_ExecStep(t *testing.T) {
 		{
 			name:    "docker-detached step container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
 				Detach:      true,
@@ -293,6 +301,7 @@ func TestLinux_ExecStep(t *testing.T) {
 		{
 			name:    "docker-step container with image not found",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -306,6 +315,7 @@ func TestLinux_ExecStep(t *testing.T) {
 		{
 			name:      "docker-empty step container",
 			failure:   true,
+			runtime:   _docker,
 			container: new(pipeline.Container),
 		},
 	}
@@ -317,7 +327,7 @@ func TestLinux_ExecStep(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(new(pipeline.Build)),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 				withStreamRequests(streamRequests),
@@ -367,8 +377,7 @@ func TestLinux_StreamStep(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
-
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -377,12 +386,14 @@ func TestLinux_StreamStep(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		logs      *library.Log
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-init step container",
 			failure: false,
+			runtime: _docker,
 			logs:    _logs,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
@@ -397,6 +408,7 @@ func TestLinux_StreamStep(t *testing.T) {
 		{
 			name:    "docker-basic step container",
 			failure: false,
+			runtime: _docker,
 			logs:    _logs,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
@@ -411,6 +423,7 @@ func TestLinux_StreamStep(t *testing.T) {
 		{
 			name:    "docker-step container with name not found",
 			failure: true,
+			runtime: _docker,
 			logs:    _logs,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_notfound",
@@ -425,6 +438,7 @@ func TestLinux_StreamStep(t *testing.T) {
 		{
 			name:      "docker-empty step container",
 			failure:   true,
+			runtime:   _docker,
 			logs:      _logs,
 			container: new(pipeline.Container),
 		},
@@ -438,7 +452,7 @@ func TestLinux_StreamStep(t *testing.T) {
 				WithPipeline(new(pipeline.Build)),
 				WithMaxLogSize(10),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)
@@ -483,7 +497,7 @@ func TestLinux_DestroyStep(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -492,11 +506,13 @@ func TestLinux_DestroyStep(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-init step container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -510,6 +526,7 @@ func TestLinux_DestroyStep(t *testing.T) {
 		{
 			name:    "docker-basic step container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -523,6 +540,7 @@ func TestLinux_DestroyStep(t *testing.T) {
 		{
 			name:    "docker-step container with ignoring name not found",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_ignorenotfound",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -542,7 +560,7 @@ func TestLinux_DestroyStep(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(new(pipeline.Build)),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)

--- a/executor/linux/step_test.go
+++ b/executor/linux/step_test.go
@@ -12,16 +12,13 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-
-	"github.com/go-vela/server/mock/server"
-
-	"github.com/go-vela/worker/internal/message"
-	"github.com/go-vela/worker/runtime/docker"
-
 	"github.com/go-vela/sdk-go/vela"
-
+	"github.com/go-vela/server/mock/server"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
+	"github.com/go-vela/worker/internal/message"
+	"github.com/go-vela/worker/runtime"
+	"github.com/go-vela/worker/runtime/docker"
 )
 
 func TestLinux_CreateStep(t *testing.T) {
@@ -39,7 +36,7 @@ func TestLinux_CreateStep(t *testing.T) {
 		t.Errorf("unable to create Vela API client: %v", err)
 	}
 
-	_runtime, err := docker.NewMock()
+	_docker, err := docker.NewMock()
 	if err != nil {
 		t.Errorf("unable to create docker runtime engine: %v", err)
 	}
@@ -48,11 +45,13 @@ func TestLinux_CreateStep(t *testing.T) {
 	tests := []struct {
 		name      string
 		failure   bool
+		runtime   runtime.Engine
 		container *pipeline.Container
 	}{
 		{
 			name:    "docker-init step container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_init",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -66,6 +65,7 @@ func TestLinux_CreateStep(t *testing.T) {
 		{
 			name:    "docker-basic step container",
 			failure: false,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -79,6 +79,7 @@ func TestLinux_CreateStep(t *testing.T) {
 		{
 			name:    "docker-step container with image not found",
 			failure: true,
+			runtime: _docker,
 			container: &pipeline.Container{
 				ID:          "step_github_octocat_1_echo",
 				Directory:   "/vela/src/github.com/github/octocat",
@@ -92,6 +93,7 @@ func TestLinux_CreateStep(t *testing.T) {
 		{
 			name:      "docker-empty step container",
 			failure:   true,
+			runtime:   _docker,
 			container: new(pipeline.Container),
 		},
 	}
@@ -103,7 +105,7 @@ func TestLinux_CreateStep(t *testing.T) {
 				WithBuild(_build),
 				WithPipeline(new(pipeline.Build)),
 				WithRepo(_repo),
-				WithRuntime(_runtime),
+				WithRuntime(test.runtime),
 				WithUser(_user),
 				WithVelaClient(_client),
 			)


### PR DESCRIPTION
@JordanSussman, @jbrockopp and I worked on adding executor tests that use the kubernetes runtime. You can see the results of that effort in the [executor-k8s-tests](https://github.com/go-vela/worker/compare/executor-k8s-tests) branch. This PR prepares for getting all of those test cases added. This PR:

- renames var: `_runtime` to `_docker` (plus a few other related var renames)
- Adds `runtime` arg (to be accessed as `test.runtime`)
- In some tests, pass in the runtime itself in `test.runtime`.
- In other tests, pass a constant because the runtime will need to be recreated for every test.
- resorted some of the imports