### PR TITLE
enhance(executor tests): test StreamBuild logging during build tests

### DIFF
--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1550,10 +1550,10 @@ func TestLinux_StreamBuild(t *testing.T) {
 	tests := []struct {
 		name           string
 		failure        bool
-		runtime        string
 		earlyExecExit  bool
 		earlyBuildDone bool
 		logError       bool
+		runtime        string
 		pipeline       string
 		msgCount       int
 		messageKey     string

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -11,21 +11,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/sdk-go/vela"
 	"github.com/go-vela/server/compiler/native"
 	"github.com/go-vela/server/mock/server"
-	"github.com/urfave/cli/v2"
-
-	"github.com/go-vela/worker/internal/message"
-	"github.com/go-vela/worker/runtime"
-	"github.com/go-vela/worker/runtime/docker"
-
-	"github.com/go-vela/sdk-go/vela"
-
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
-
-	"github.com/gin-gonic/gin"
+	"github.com/go-vela/worker/internal/message"
+	"github.com/go-vela/worker/runtime"
+	"github.com/go-vela/worker/runtime/docker"
+	"github.com/urfave/cli/v2"
 )
 
 func TestLinux_CreateBuild(t *testing.T) {


### PR DESCRIPTION
@JordanSussman, @jbrockopp and I worked on adding executor tests that use the kubernetes runtime. You can see the results of that effort in the [executor-k8s-tests](https://github.com/go-vela/worker/compare/executor-k8s-tests) branch. This PR prepares for getting all of those test cases added. This PR:

- sorts the imports in `executor/linux/build_test.go`
- adjusts tests in `executor/linux/build_test.go` to check for logging un/expected errors. This is needed because logs are the only way to know if some areas of the code get hit, and because the logging happens in a goroutine, so we need to check the behavior of that goroutine when the function under test is doing its thing.