### PR TITLE
enhance(executor tests): Sanitize pipelines to handle runtime specific differences

### DIFF
--- a/executor/linux/api_test.go
+++ b/executor/linux/api_test.go
@@ -64,7 +64,7 @@ func TestLinux_GetBuild(t *testing.T) {
 
 func TestLinux_GetPipeline(t *testing.T) {
 	// setup types
-	_steps := testSteps()
+	_steps := testSteps("docker")
 
 	_engine, err := New(
 		WithPipeline(_steps),

--- a/executor/linux/api_test.go
+++ b/executor/linux/api_test.go
@@ -7,6 +7,8 @@ package linux
 import (
 	"reflect"
 	"testing"
+
+	"github.com/go-vela/types/constants"
 )
 
 func TestLinux_GetBuild(t *testing.T) {
@@ -64,7 +66,7 @@ func TestLinux_GetBuild(t *testing.T) {
 
 func TestLinux_GetPipeline(t *testing.T) {
 	// setup types
-	_steps := testSteps("docker")
+	_steps := testSteps(constants.DriverDocker)
 
 	_engine, err := New(
 		WithPipeline(_steps),

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -115,6 +115,9 @@ func TestLinux_CreateBuild(t *testing.T) {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
 			}
 
+			// Docker uses _ while Kubernetes uses -
+			_pipeline = _pipeline.Sanitize(test.runtime)
+
 			var _runtime runtime.Engine
 
 			switch test.runtime {
@@ -1074,6 +1077,9 @@ func TestLinux_PlanBuild(t *testing.T) {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
 			}
 
+			// Docker uses _ while Kubernetes uses -
+			_pipeline = _pipeline.Sanitize(test.runtime)
+
 			var _runtime runtime.Engine
 
 			switch test.runtime {
@@ -1269,6 +1275,9 @@ func TestLinux_AssembleBuild(t *testing.T) {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
 			}
 
+			// Docker uses _ while Kubernetes uses -
+			_pipeline = _pipeline.Sanitize(test.runtime)
+
 			var _runtime runtime.Engine
 
 			switch test.runtime {
@@ -1419,6 +1428,9 @@ func TestLinux_ExecBuild(t *testing.T) {
 			if err != nil {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
 			}
+
+			// Docker uses _ while Kubernetes uses -
+			_pipeline = _pipeline.Sanitize(test.runtime)
 
 			var _runtime runtime.Engine
 
@@ -1800,6 +1812,9 @@ func TestLinux_StreamBuild(t *testing.T) {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
 			}
 
+			// Docker uses _ while Kubernetes uses -
+			_pipeline = _pipeline.Sanitize(test.runtime)
+
 			var _runtime runtime.Engine
 
 			switch test.runtime {
@@ -2002,6 +2017,9 @@ func TestLinux_DestroyBuild(t *testing.T) {
 			if err != nil {
 				t.Errorf("unable to compile %s pipeline %s: %v", test.name, test.pipeline, err)
 			}
+
+			// Docker uses _ while Kubernetes uses -
+			_pipeline = _pipeline.Sanitize(test.runtime)
 
 			var _runtime runtime.Engine
 

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1462,7 +1462,7 @@ func TestLinux_ExecBuild(t *testing.T) {
 			// run create to init steps to be created properly
 			err = _engine.CreateBuild(context.Background())
 			if err != nil {
-				t.Errorf("unable to create build: %v", err)
+				t.Errorf("%s unable to create build: %v", test.name, err)
 			}
 
 			// TODO: hack - remove this

--- a/executor/linux/driver_test.go
+++ b/executor/linux/driver_test.go
@@ -37,7 +37,7 @@ func TestLinux_Driver(t *testing.T) {
 	_engine, err := New(
 		WithBuild(testBuild()),
 		WithHostname("localhost"),
-		WithPipeline(testSteps("docker")),
+		WithPipeline(testSteps(constants.DriverDocker)),
 		WithRepo(testRepo()),
 		WithRuntime(_runtime),
 		WithUser(testUser()),

--- a/executor/linux/driver_test.go
+++ b/executor/linux/driver_test.go
@@ -37,7 +37,7 @@ func TestLinux_Driver(t *testing.T) {
 	_engine, err := New(
 		WithBuild(testBuild()),
 		WithHostname("localhost"),
-		WithPipeline(testSteps()),
+		WithPipeline(testSteps("docker")),
 		WithRepo(testRepo()),
 		WithRuntime(_runtime),
 		WithUser(testUser()),

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-vela/server/mock/server"
 	"github.com/go-vela/types"
+	"github.com/go-vela/types/constants"
 
 	"github.com/go-vela/worker/runtime/docker"
 
@@ -40,7 +41,7 @@ func TestEqual(t *testing.T) {
 	_linux, err := New(
 		WithBuild(testBuild()),
 		WithHostname("localhost"),
-		WithPipeline(testSteps("docker")),
+		WithPipeline(testSteps(constants.DriverDocker)),
 		WithRepo(testRepo()),
 		WithRuntime(_runtime),
 		WithUser(testUser()),
@@ -53,7 +54,7 @@ func TestEqual(t *testing.T) {
 	_alternate, err := New(
 		WithBuild(testBuild()),
 		WithHostname("a.different.host"),
-		WithPipeline(testSteps("docker")),
+		WithPipeline(testSteps(constants.DriverDocker)),
 		WithRepo(testRepo()),
 		WithRuntime(_runtime),
 		WithUser(testUser()),
@@ -149,7 +150,7 @@ func TestLinux_New(t *testing.T) {
 			_, err := New(
 				WithBuild(test.build),
 				WithHostname("localhost"),
-				WithPipeline(testSteps("docker")),
+				WithPipeline(testSteps(constants.DriverDocker)),
 				WithRepo(testRepo()),
 				WithRuntime(_runtime),
 				WithUser(testUser()),
@@ -266,7 +267,7 @@ func testMetadata() *types.Metadata {
 // testSteps is a test helper function to create a steps
 // pipeline with fake steps.
 func testSteps(runtime string) *pipeline.Build {
-	if runtime == "kubernetes" {
+	if runtime == constants.DriverKubernetes {
 		return &pipeline.Build{
 			Version: "1",
 			ID:      "github-octocat-1",
@@ -336,75 +337,76 @@ func testSteps(runtime string) *pipeline.Build {
 				},
 			},
 		}
-	} else { // docker
-		return &pipeline.Build{
-			Version: "1",
-			ID:      "github_octocat_1",
-			Services: pipeline.ContainerSlice{
-				{
-					ID:          "service_github_octocat_1_postgres",
-					Directory:   "/home/github/octocat",
-					Environment: map[string]string{"FOO": "bar"},
-					Image:       "postgres:12-alpine",
-					Name:        "postgres",
-					Number:      1,
-					Ports:       []string{"5432:5432"},
-					Pull:        "not_present",
-				},
+	}
+
+	// else docker
+	return &pipeline.Build{
+		Version: "1",
+		ID:      "github_octocat_1",
+		Services: pipeline.ContainerSlice{
+			{
+				ID:          "service_github_octocat_1_postgres",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "postgres:12-alpine",
+				Name:        "postgres",
+				Number:      1,
+				Ports:       []string{"5432:5432"},
+				Pull:        "not_present",
 			},
-			Steps: pipeline.ContainerSlice{
-				{
-					ID:          "step_github_octocat_1_init",
-					Directory:   "/home/github/octocat",
-					Environment: map[string]string{"FOO": "bar"},
-					Image:       "#init",
-					Name:        "init",
-					Number:      1,
-					Pull:        "always",
-				},
-				{
-					ID:          "step_github_octocat_1_clone",
-					Directory:   "/home/github/octocat",
-					Environment: map[string]string{"FOO": "bar"},
-					Image:       "target/vela-git:v0.3.0",
-					Name:        "clone",
-					Number:      2,
-					Pull:        "always",
-				},
-				{
-					ID:          "step_github_octocat_1_echo",
-					Commands:    []string{"echo hello"},
-					Directory:   "/home/github/octocat",
-					Environment: map[string]string{"FOO": "bar"},
-					Image:       "alpine:latest",
-					Name:        "echo",
-					Number:      3,
-					Pull:        "always",
-				},
+		},
+		Steps: pipeline.ContainerSlice{
+			{
+				ID:          "step_github_octocat_1_init",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "#init",
+				Name:        "init",
+				Number:      1,
+				Pull:        "always",
 			},
-			Secrets: pipeline.SecretSlice{
-				{
-					Name:   "foo",
-					Key:    "github/octocat/foo",
-					Engine: "native",
-					Type:   "repo",
-					Origin: &pipeline.Container{},
-				},
-				{
-					Name:   "foo",
-					Key:    "github/foo",
-					Engine: "native",
-					Type:   "org",
-					Origin: &pipeline.Container{},
-				},
-				{
-					Name:   "foo",
-					Key:    "github/octokitties/foo",
-					Engine: "native",
-					Type:   "shared",
-					Origin: &pipeline.Container{},
-				},
+			{
+				ID:          "step_github_octocat_1_clone",
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "target/vela-git:v0.3.0",
+				Name:        "clone",
+				Number:      2,
+				Pull:        "always",
 			},
-		}
+			{
+				ID:          "step_github_octocat_1_echo",
+				Commands:    []string{"echo hello"},
+				Directory:   "/home/github/octocat",
+				Environment: map[string]string{"FOO": "bar"},
+				Image:       "alpine:latest",
+				Name:        "echo",
+				Number:      3,
+				Pull:        "always",
+			},
+		},
+		Secrets: pipeline.SecretSlice{
+			{
+				Name:   "foo",
+				Key:    "github/octocat/foo",
+				Engine: "native",
+				Type:   "repo",
+				Origin: &pipeline.Container{},
+			},
+			{
+				Name:   "foo",
+				Key:    "github/foo",
+				Engine: "native",
+				Type:   "org",
+				Origin: &pipeline.Container{},
+			},
+			{
+				Name:   "foo",
+				Key:    "github/octokitties/foo",
+				Engine: "native",
+				Type:   "shared",
+				Origin: &pipeline.Container{},
+			},
+		},
 	}
 }

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -267,80 +267,7 @@ func testMetadata() *types.Metadata {
 // testSteps is a test helper function to create a steps
 // pipeline with fake steps.
 func testSteps(runtime string) *pipeline.Build {
-	if runtime == constants.DriverKubernetes {
-		return &pipeline.Build{
-			Version: "1",
-			ID:      "github-octocat-1",
-			Services: pipeline.ContainerSlice{
-				{
-					ID:          "service-github-octocat-1-postgres",
-					Directory:   "/home/github/octocat",
-					Environment: map[string]string{"FOO": "bar"},
-					Image:       "postgres:12-alpine",
-					Name:        "postgres",
-					Number:      1,
-					Ports:       []string{"5432:5432"},
-					Pull:        "not_present",
-				},
-			},
-			Steps: pipeline.ContainerSlice{
-				{
-					ID:          "step-github-octocat-1-init",
-					Directory:   "/home/github/octocat",
-					Environment: map[string]string{"FOO": "bar"},
-					Image:       "#init",
-					Name:        "init",
-					Number:      1,
-					Pull:        "always",
-				},
-				{
-					ID:          "step-github-octocat-1-clone",
-					Directory:   "/home/github/octocat",
-					Environment: map[string]string{"FOO": "bar"},
-					Image:       "target/vela-git:v0.3.0",
-					Name:        "clone",
-					Number:      2,
-					Pull:        "always",
-				},
-				{
-					ID:          "step-github-octocat-1-echo",
-					Commands:    []string{"echo hello"},
-					Directory:   "/home/github/octocat",
-					Environment: map[string]string{"FOO": "bar"},
-					Image:       "alpine:latest",
-					Name:        "echo",
-					Number:      3,
-					Pull:        "always",
-				},
-			},
-			Secrets: pipeline.SecretSlice{
-				{
-					Name:   "foo",
-					Key:    "github/octocat/foo",
-					Engine: "native",
-					Type:   "repo",
-					Origin: &pipeline.Container{},
-				},
-				{
-					Name:   "foo",
-					Key:    "github/foo",
-					Engine: "native",
-					Type:   "org",
-					Origin: &pipeline.Container{},
-				},
-				{
-					Name:   "foo",
-					Key:    "github/octokitties/foo",
-					Engine: "native",
-					Type:   "shared",
-					Origin: &pipeline.Container{},
-				},
-			},
-		}
-	}
-
-	// else docker
-	return &pipeline.Build{
+	steps := &pipeline.Build{
 		Version: "1",
 		ID:      "github_octocat_1",
 		Services: pipeline.ContainerSlice{
@@ -409,4 +336,7 @@ func testSteps(runtime string) *pipeline.Build {
 			},
 		},
 	}
+
+	// apply any runtime-specific cleanups
+	return steps.Sanitize(runtime)
 }

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -40,7 +40,7 @@ func TestEqual(t *testing.T) {
 	_linux, err := New(
 		WithBuild(testBuild()),
 		WithHostname("localhost"),
-		WithPipeline(testSteps()),
+		WithPipeline(testSteps("docker")),
 		WithRepo(testRepo()),
 		WithRuntime(_runtime),
 		WithUser(testUser()),
@@ -53,7 +53,7 @@ func TestEqual(t *testing.T) {
 	_alternate, err := New(
 		WithBuild(testBuild()),
 		WithHostname("a.different.host"),
-		WithPipeline(testSteps()),
+		WithPipeline(testSteps("docker")),
 		WithRepo(testRepo()),
 		WithRuntime(_runtime),
 		WithUser(testUser()),
@@ -149,7 +149,7 @@ func TestLinux_New(t *testing.T) {
 			_, err := New(
 				WithBuild(test.build),
 				WithHostname("localhost"),
-				WithPipeline(testSteps()),
+				WithPipeline(testSteps("docker")),
 				WithRepo(testRepo()),
 				WithRuntime(_runtime),
 				WithUser(testUser()),
@@ -265,74 +265,146 @@ func testMetadata() *types.Metadata {
 
 // testSteps is a test helper function to create a steps
 // pipeline with fake steps.
-func testSteps() *pipeline.Build {
-	return &pipeline.Build{
-		Version: "1",
-		ID:      "github_octocat_1",
-		Services: pipeline.ContainerSlice{
-			{
-				ID:          "service_github_octocat_1_postgres",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "postgres:12-alpine",
-				Name:        "postgres",
-				Number:      1,
-				Ports:       []string{"5432:5432"},
-				Pull:        "not_present",
+func testSteps(runtime string) *pipeline.Build {
+	if runtime == "kubernetes" {
+		return &pipeline.Build{
+			Version: "1",
+			ID:      "github-octocat-1",
+			Services: pipeline.ContainerSlice{
+				{
+					ID:          "service-github-octocat-1-postgres",
+					Directory:   "/home/github/octocat",
+					Environment: map[string]string{"FOO": "bar"},
+					Image:       "postgres:12-alpine",
+					Name:        "postgres",
+					Number:      1,
+					Ports:       []string{"5432:5432"},
+					Pull:        "not_present",
+				},
 			},
-		},
-		Steps: pipeline.ContainerSlice{
-			{
-				ID:          "step_github_octocat_1_init",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "#init",
-				Name:        "init",
-				Number:      1,
-				Pull:        "always",
+			Steps: pipeline.ContainerSlice{
+				{
+					ID:          "step-github-octocat-1-init",
+					Directory:   "/home/github/octocat",
+					Environment: map[string]string{"FOO": "bar"},
+					Image:       "#init",
+					Name:        "init",
+					Number:      1,
+					Pull:        "always",
+				},
+				{
+					ID:          "step-github-octocat-1-clone",
+					Directory:   "/home/github/octocat",
+					Environment: map[string]string{"FOO": "bar"},
+					Image:       "target/vela-git:v0.3.0",
+					Name:        "clone",
+					Number:      2,
+					Pull:        "always",
+				},
+				{
+					ID:          "step-github-octocat-1-echo",
+					Commands:    []string{"echo hello"},
+					Directory:   "/home/github/octocat",
+					Environment: map[string]string{"FOO": "bar"},
+					Image:       "alpine:latest",
+					Name:        "echo",
+					Number:      3,
+					Pull:        "always",
+				},
 			},
-			{
-				ID:          "step_github_octocat_1_clone",
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "target/vela-git:v0.3.0",
-				Name:        "clone",
-				Number:      2,
-				Pull:        "always",
+			Secrets: pipeline.SecretSlice{
+				{
+					Name:   "foo",
+					Key:    "github/octocat/foo",
+					Engine: "native",
+					Type:   "repo",
+					Origin: &pipeline.Container{},
+				},
+				{
+					Name:   "foo",
+					Key:    "github/foo",
+					Engine: "native",
+					Type:   "org",
+					Origin: &pipeline.Container{},
+				},
+				{
+					Name:   "foo",
+					Key:    "github/octokitties/foo",
+					Engine: "native",
+					Type:   "shared",
+					Origin: &pipeline.Container{},
+				},
 			},
-			{
-				ID:          "step_github_octocat_1_echo",
-				Commands:    []string{"echo hello"},
-				Directory:   "/home/github/octocat",
-				Environment: map[string]string{"FOO": "bar"},
-				Image:       "alpine:latest",
-				Name:        "echo",
-				Number:      3,
-				Pull:        "always",
+		}
+	} else { // docker
+		return &pipeline.Build{
+			Version: "1",
+			ID:      "github_octocat_1",
+			Services: pipeline.ContainerSlice{
+				{
+					ID:          "service_github_octocat_1_postgres",
+					Directory:   "/home/github/octocat",
+					Environment: map[string]string{"FOO": "bar"},
+					Image:       "postgres:12-alpine",
+					Name:        "postgres",
+					Number:      1,
+					Ports:       []string{"5432:5432"},
+					Pull:        "not_present",
+				},
 			},
-		},
-		Secrets: pipeline.SecretSlice{
-			{
-				Name:   "foo",
-				Key:    "github/octocat/foo",
-				Engine: "native",
-				Type:   "repo",
-				Origin: &pipeline.Container{},
+			Steps: pipeline.ContainerSlice{
+				{
+					ID:          "step_github_octocat_1_init",
+					Directory:   "/home/github/octocat",
+					Environment: map[string]string{"FOO": "bar"},
+					Image:       "#init",
+					Name:        "init",
+					Number:      1,
+					Pull:        "always",
+				},
+				{
+					ID:          "step_github_octocat_1_clone",
+					Directory:   "/home/github/octocat",
+					Environment: map[string]string{"FOO": "bar"},
+					Image:       "target/vela-git:v0.3.0",
+					Name:        "clone",
+					Number:      2,
+					Pull:        "always",
+				},
+				{
+					ID:          "step_github_octocat_1_echo",
+					Commands:    []string{"echo hello"},
+					Directory:   "/home/github/octocat",
+					Environment: map[string]string{"FOO": "bar"},
+					Image:       "alpine:latest",
+					Name:        "echo",
+					Number:      3,
+					Pull:        "always",
+				},
 			},
-			{
-				Name:   "foo",
-				Key:    "github/foo",
-				Engine: "native",
-				Type:   "org",
-				Origin: &pipeline.Container{},
+			Secrets: pipeline.SecretSlice{
+				{
+					Name:   "foo",
+					Key:    "github/octocat/foo",
+					Engine: "native",
+					Type:   "repo",
+					Origin: &pipeline.Container{},
+				},
+				{
+					Name:   "foo",
+					Key:    "github/foo",
+					Engine: "native",
+					Type:   "org",
+					Origin: &pipeline.Container{},
+				},
+				{
+					Name:   "foo",
+					Key:    "github/octokitties/foo",
+					Engine: "native",
+					Type:   "shared",
+					Origin: &pipeline.Container{},
+				},
 			},
-			{
-				Name:   "foo",
-				Key:    "github/octokitties/foo",
-				Engine: "native",
-				Type:   "shared",
-				Origin: &pipeline.Container{},
-			},
-		},
+		}
 	}
 }

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -9,17 +9,13 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-
+	"github.com/go-vela/sdk-go/vela"
 	"github.com/go-vela/server/mock/server"
 	"github.com/go-vela/types"
 	"github.com/go-vela/types/constants"
-
-	"github.com/go-vela/worker/runtime/docker"
-
-	"github.com/go-vela/sdk-go/vela"
-
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
+	"github.com/go-vela/worker/runtime/docker"
 )
 
 func TestEqual(t *testing.T) {

--- a/executor/linux/opts_test.go
+++ b/executor/linux/opts_test.go
@@ -11,18 +11,14 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
-
-	"github.com/go-vela/server/mock/server"
-
-	"github.com/go-vela/worker/runtime"
-	"github.com/go-vela/worker/runtime/docker"
-
 	"github.com/go-vela/sdk-go/vela"
-
+	"github.com/go-vela/server/mock/server"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
+	"github.com/go-vela/worker/runtime"
+	"github.com/go-vela/worker/runtime/docker"
+	"github.com/sirupsen/logrus"
 )
 
 func TestLinux_Opt_WithBuild(t *testing.T) {

--- a/executor/linux/opts_test.go
+++ b/executor/linux/opts_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-vela/sdk-go/vela"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
 )
@@ -384,7 +385,7 @@ func TestLinux_Opt_WithLogger(t *testing.T) {
 
 func TestLinux_Opt_WithPipeline(t *testing.T) {
 	// setup types
-	_steps := testSteps("docker")
+	_steps := testSteps(constants.DriverDocker)
 
 	// setup tests
 	tests := []struct {

--- a/executor/linux/opts_test.go
+++ b/executor/linux/opts_test.go
@@ -384,7 +384,7 @@ func TestLinux_Opt_WithLogger(t *testing.T) {
 
 func TestLinux_Opt_WithPipeline(t *testing.T) {
 	// setup types
-	_steps := testSteps()
+	_steps := testSteps("docker")
 
 	// setup tests
 	tests := []struct {

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -12,22 +12,17 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/urfave/cli/v2"
-
+	"github.com/go-vela/sdk-go/vela"
 	"github.com/go-vela/server/compiler/native"
 	"github.com/go-vela/server/mock/server"
-
-	"github.com/go-vela/worker/internal/message"
-	"github.com/go-vela/worker/runtime"
-	"github.com/go-vela/worker/runtime/docker"
-
-	"github.com/go-vela/sdk-go/vela"
-
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
-
+	"github.com/go-vela/worker/internal/message"
+	"github.com/go-vela/worker/runtime"
+	"github.com/go-vela/worker/runtime/docker"
 	"github.com/google/go-cmp/cmp"
+	"github.com/urfave/cli/v2"
 )
 
 func TestLinux_Secret_create(t *testing.T) {

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -35,7 +35,7 @@ func TestLinux_Secret_create(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps()
+	_steps := testSteps("docker")
 
 	gin.SetMode(gin.TestMode)
 
@@ -125,7 +125,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps()
+	_dockerSteps := testSteps("docker")
 
 	gin.SetMode(gin.TestMode)
 
@@ -153,6 +153,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 		runtime   runtime.Engine
 		container *pipeline.Container
 		step      *library.Step
+		steps     *pipeline.Build
 	}{
 		{
 			name:    "docker-running container-empty step",
@@ -167,7 +168,8 @@ func TestLinux_Secret_delete(t *testing.T) {
 				Number:      1,
 				Pull:        "always",
 			},
-			step: new(library.Step),
+			step:  new(library.Step),
+			steps: _dockerSteps,
 		},
 		{
 			name:    "docker-running container-pending step",
@@ -182,7 +184,8 @@ func TestLinux_Secret_delete(t *testing.T) {
 				Number:      2,
 				Pull:        "always",
 			},
-			step: _step,
+			step:  _step,
+			steps: _dockerSteps,
 		},
 		{
 			name:    "docker-inspecting container failure due to invalid container id",
@@ -197,7 +200,8 @@ func TestLinux_Secret_delete(t *testing.T) {
 				Number:      2,
 				Pull:        "always",
 			},
-			step: new(library.Step),
+			step:  new(library.Step),
+			steps: _dockerSteps,
 		},
 		{
 			name:    "docker-removing container failure",
@@ -212,7 +216,8 @@ func TestLinux_Secret_delete(t *testing.T) {
 				Number:      2,
 				Pull:        "always",
 			},
-			step: new(library.Step),
+			step:  new(library.Step),
+			steps: _dockerSteps,
 		},
 	}
 
@@ -221,7 +226,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_engine, err := New(
 				WithBuild(_build),
-				WithPipeline(_steps),
+				WithPipeline(test.steps),
 				WithRepo(_repo),
 				WithRuntime(test.runtime),
 				WithUser(_user),
@@ -506,7 +511,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_engine, err := New(
 				WithBuild(_build),
-				WithPipeline(testSteps()),
+				WithPipeline(testSteps("docker")),
 				WithRepo(_repo),
 				WithRuntime(test.runtime),
 				WithUser(_user),
@@ -538,7 +543,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps()
+	_steps := testSteps("docker")
 
 	gin.SetMode(gin.TestMode)
 

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -35,7 +35,7 @@ func TestLinux_Secret_create(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps("docker")
+	_steps := testSteps(constants.DriverDocker)
 
 	gin.SetMode(gin.TestMode)
 
@@ -125,7 +125,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_dockerSteps := testSteps("docker")
+	_dockerSteps := testSteps(constants.DriverDocker)
 
 	gin.SetMode(gin.TestMode)
 
@@ -511,7 +511,7 @@ func TestLinux_Secret_pull(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_engine, err := New(
 				WithBuild(_build),
-				WithPipeline(testSteps("docker")),
+				WithPipeline(testSteps(constants.DriverDocker)),
 				WithRepo(_repo),
 				WithRuntime(test.runtime),
 				WithUser(_user),
@@ -543,7 +543,7 @@ func TestLinux_Secret_stream(t *testing.T) {
 	_build := testBuild()
 	_repo := testRepo()
 	_user := testUser()
-	_steps := testSteps("docker")
+	_steps := testSteps(constants.DriverDocker)
 
 	gin.SetMode(gin.TestMode)
 

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -236,6 +236,7 @@ func TestLinux_Secret_delete(t *testing.T) {
 				t.Errorf("unable to create %s executor engine: %v", test.name, err)
 			}
 
+			// add init container info to client
 			_ = _engine.CreateBuild(context.Background())
 
 			_engine.steps.Store(test.container.ID, test.step)
@@ -314,6 +315,9 @@ func TestLinux_Secret_exec(t *testing.T) {
 			if err != nil {
 				t.Errorf("unable to compile pipeline %s: %v", test.pipeline, err)
 			}
+
+			// Docker uses _ while Kubernetes uses -
+			p = p.Sanitize(test.runtime)
 
 			var _runtime runtime.Engine
 


### PR DESCRIPTION
@JordanSussman, @jbrockopp and I worked on adding executor tests that use the kubernetes runtime. You can see the results of that effort in the [executor-k8s-tests](https://github.com/go-vela/worker/compare/executor-k8s-tests) branch. This PR prepares for getting all of those test cases added. This PR:

- modify the `testSteps` test helper to accept a runtime argument
- calls `pipeline.Sanitize(runtime)` in the `testSteps` helper to sanitize container/build names for the given runtime
- calls `pipeline.Sanitize(runtime)` in tests as well, where required

This was a smaller PR, so I also included:
- enhance: update error message that was missing a test.name
- chore: sorts some imports
