### PR TITLE
enhance(executor tests): Add test helpers to generate test Pods

### DIFF
--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1090,6 +1090,12 @@ func TestLinux_PlanBuild(t *testing.T) {
 			var _runtime runtime.Engine
 
 			switch test.runtime {
+			case constants.DriverKubernetes:
+				_pod := testPodFor(_pipeline)
+				_runtime, err = kubernetes.NewMock(_pod)
+				if err != nil {
+					t.Errorf("unable to create kubernetes runtime engine: %v", err)
+				}
 			case constants.DriverDocker:
 				_runtime, err = docker.NewMock()
 				if err != nil {
@@ -1288,6 +1294,12 @@ func TestLinux_AssembleBuild(t *testing.T) {
 			var _runtime runtime.Engine
 
 			switch test.runtime {
+			case constants.DriverKubernetes:
+				_pod := testPodFor(_pipeline)
+				_runtime, err = kubernetes.NewMock(_pod)
+				if err != nil {
+					t.Errorf("unable to create kubernetes runtime engine: %v", err)
+				}
 			case constants.DriverDocker:
 				_runtime, err = docker.NewMock()
 				if err != nil {
@@ -1442,6 +1454,12 @@ func TestLinux_ExecBuild(t *testing.T) {
 			var _runtime runtime.Engine
 
 			switch test.runtime {
+			case constants.DriverKubernetes:
+				_pod := testPodFor(_pipeline)
+				_runtime, err = kubernetes.NewMock(_pod)
+				if err != nil {
+					t.Errorf("unable to create kubernetes runtime engine: %v", err)
+				}
 			case constants.DriverDocker:
 				_runtime, err = docker.NewMock()
 				if err != nil {
@@ -1825,6 +1843,12 @@ func TestLinux_StreamBuild(t *testing.T) {
 			var _runtime runtime.Engine
 
 			switch test.runtime {
+			case constants.DriverKubernetes:
+				_pod := testPodFor(_pipeline)
+				_runtime, err = kubernetes.NewMock(_pod)
+				if err != nil {
+					t.Errorf("unable to create kubernetes runtime engine: %v", err)
+				}
 			case constants.DriverDocker:
 				_runtime, err = docker.NewMock()
 				if err != nil {
@@ -2031,6 +2055,12 @@ func TestLinux_DestroyBuild(t *testing.T) {
 			var _runtime runtime.Engine
 
 			switch test.runtime {
+			case constants.DriverKubernetes:
+				_pod := testPodFor(_pipeline)
+				_runtime, err = kubernetes.NewMock(_pod)
+				if err != nil {
+					t.Errorf("unable to create kubernetes runtime engine: %v", err)
+				}
 			case constants.DriverDocker:
 				_runtime, err = docker.NewMock()
 				if err != nil {

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-vela/worker/internal/message"
 	"github.com/go-vela/worker/runtime"
 	"github.com/go-vela/worker/runtime/docker"
+	"github.com/go-vela/worker/runtime/kubernetes"
 	"github.com/sirupsen/logrus"
 	logrusTest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/urfave/cli/v2"
@@ -121,6 +122,12 @@ func TestLinux_CreateBuild(t *testing.T) {
 			var _runtime runtime.Engine
 
 			switch test.runtime {
+			case constants.DriverKubernetes:
+				_pod := testPodFor(_pipeline)
+				_runtime, err = kubernetes.NewMock(_pod)
+				if err != nil {
+					t.Errorf("unable to create kubernetes runtime engine: %v", err)
+				}
 			case constants.DriverDocker:
 				_runtime, err = docker.NewMock()
 				if err != nil {

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-vela/sdk-go/vela"
 	"github.com/go-vela/server/compiler/native"
@@ -1451,11 +1453,14 @@ func TestLinux_ExecBuild(t *testing.T) {
 			// Docker uses _ while Kubernetes uses -
 			_pipeline = _pipeline.Sanitize(test.runtime)
 
-			var _runtime runtime.Engine
+			var (
+				_runtime runtime.Engine
+				_pod     *v1.Pod
+			)
 
 			switch test.runtime {
 			case constants.DriverKubernetes:
-				_pod := testPodFor(_pipeline)
+				_pod = testPodFor(_pipeline)
 				_runtime, err = kubernetes.NewMock(_pod)
 				if err != nil {
 					t.Errorf("unable to create kubernetes runtime engine: %v", err)

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -418,3 +418,81 @@ var _pod = &v1.Pod{
 		},
 	},
 }
+
+var _stagePod = &v1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "github-octocat-1",
+		Namespace: "test",
+		Labels: map[string]string{
+			"pipeline": "github-octocat-1",
+		},
+	},
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "Pod",
+	},
+	Status: v1.PodStatus{
+		Phase: v1.PodRunning,
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name: "github-octocat-1-clone-clone",
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						Reason:   "Completed",
+						ExitCode: 0,
+					},
+				},
+				Image: "target/vela-git:v0.6.0",
+			},
+			{
+				Name: "github-octocat-1-echo-echo",
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						Reason:   "Completed",
+						ExitCode: 0,
+					},
+				},
+				Image: "alpine:latest",
+			},
+		},
+	},
+	Spec: v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:            "github-octocat-1-clone-clone",
+				Image:           "target/vela-git:v0.6.0",
+				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+				ImagePullPolicy: v1.PullAlways,
+			},
+			{
+				Name:            "github-octocat-1-echo-echo",
+				Image:           "alpine:latest",
+				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+				ImagePullPolicy: v1.PullAlways,
+			},
+			{
+				Name:            "service-github-octocat-1-postgres",
+				Image:           "postgres:12-alpine",
+				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+				ImagePullPolicy: v1.PullAlways,
+			},
+		},
+		HostAliases: []v1.HostAlias{
+			{
+				IP: "127.0.0.1",
+				Hostnames: []string{
+					"postgres.local",
+					"echo.local",
+				},
+			},
+		},
+		Volumes: []v1.Volume{
+			{
+				Name: "github-octocat-1",
+				VolumeSource: v1.VolumeSource{
+					EmptyDir: &v1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+	},
+}

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -556,6 +556,17 @@ func testPodFor(build *pipeline.Build) *v1.Pod {
 			// secret.Origin.Pull should be one of: Always, Never, IfNotPresent
 			ImagePullPolicy: v1.PullPolicy(secret.Origin.Pull),
 		})
+
+		containerStatuses = append(containerStatuses, v1.ContainerStatus{
+			Name:  secret.Origin.ID,
+			Image: secret.Origin.Image,
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{
+					Reason:   "Completed",
+					ExitCode: 0,
+				},
+			},
+		})
 	}
 
 	pod.Spec.Containers = containers

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -5,6 +5,7 @@
 package linux
 
 import (
+	"math"
 	"net/http/httptest"
 	"testing"
 
@@ -457,9 +458,8 @@ func testPod(useStages bool) *v1.Pod {
 // using container names from a test pipeline.
 func testPodFor(build *pipeline.Build) *v1.Pod {
 	var (
-		pod               *v1.Pod
-		containers        []v1.Container
-		containerStatuses []v1.ContainerStatus
+		pod        *v1.Pod
+		containers []v1.Container
 	)
 
 	workingDir := "/vela/src/github.com/octocat/helloworld"
@@ -483,34 +483,12 @@ func testPodFor(build *pipeline.Build) *v1.Pod {
 			WorkingDir:      workingDir,
 			ImagePullPolicy: v1.PullAlways,
 		})
-
-		containerStatuses = append(containerStatuses, v1.ContainerStatus{
-			Name: "step-github-octocat-1-clone-clone",
-			State: v1.ContainerState{
-				Terminated: &v1.ContainerStateTerminated{
-					Reason:   "Completed",
-					ExitCode: 0,
-				},
-			},
-			Image: "target/vela-git:v0.6.0",
-		})
 	} else { // steps
 		containers = append(containers, v1.Container{
 			Name:            "step-github-octocat-1-clone",
 			Image:           "target/vela-git:v0.6.0",
 			WorkingDir:      workingDir,
 			ImagePullPolicy: v1.PullAlways,
-		})
-
-		containerStatuses = append(containerStatuses, v1.ContainerStatus{
-			Name: "step-github-octocat-1-clone",
-			State: v1.ContainerState{
-				Terminated: &v1.ContainerStateTerminated{
-					Reason:   "Completed",
-					ExitCode: 0,
-				},
-			},
-			Image: "target/vela-git:v0.6.0",
 		})
 	}
 
@@ -556,6 +534,158 @@ func testPodFor(build *pipeline.Build) *v1.Pod {
 			// secret.Origin.Pull should be one of: Always, Never, IfNotPresent
 			ImagePullPolicy: v1.PullPolicy(secret.Origin.Pull),
 		})
+	}
+
+	pod.Spec.Containers = containers
+	pod.Status.ContainerStatuses = testContainerStatuses(build, false, 0, 0)
+
+	return pod
+}
+
+// countBuildSteps counts the steps in the build.
+func countBuildSteps(build *pipeline.Build) int {
+	steps := 0
+
+	for _, stage := range build.Stages {
+		for _, step := range stage.Steps {
+			if step.Name == "init" {
+				continue
+			}
+
+			steps++
+		}
+	}
+
+	for _, step := range build.Steps {
+		if step.Name == "init" {
+			continue
+		}
+
+		steps++
+	}
+
+	return steps
+}
+
+// testContainerStatuses is a test helper function to create a ContainerStatuses list.
+func testContainerStatuses(build *pipeline.Build, servicesRunning bool, stepsRunningCount, stepsCompletedPercent int) []v1.ContainerStatus {
+	var containerStatuses []v1.ContainerStatus
+
+	useStages := len(build.Stages) > 0
+	stepsCompletedCount := 0
+
+	if stepsCompletedPercent > 0 {
+		stepsCompletedCount = int(math.Round(float64(stepsCompletedPercent) / 100 * float64(countBuildSteps(build))))
+	}
+
+	if servicesRunning {
+		for _, service := range build.Services {
+			containerStatuses = append(containerStatuses, v1.ContainerStatus{
+				Name: service.ID,
+				State: v1.ContainerState{
+					Running: &v1.ContainerStateRunning{},
+				},
+				Image: service.Image,
+			})
+		}
+	}
+
+	if useStages {
+		containerStatuses = append(containerStatuses, v1.ContainerStatus{
+			Name: "step-github-octocat-1-clone-clone",
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{
+					Reason:   "Completed",
+					ExitCode: 0,
+				},
+			},
+			Image: "target/vela-git:v0.6.0",
+		})
+	} else { // steps
+		containerStatuses = append(containerStatuses, v1.ContainerStatus{
+			Name: "step-github-octocat-1-clone",
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{
+					Reason:   "Completed",
+					ExitCode: 0,
+				},
+			},
+			Image: "target/vela-git:v0.6.0",
+		})
+	}
+
+	steps := 0
+
+	for _, stage := range build.Stages {
+		for _, step := range stage.Steps {
+			if step.Name == "init" {
+				continue
+			}
+
+			steps++
+			if steps > stepsCompletedCount+stepsRunningCount {
+				break
+			}
+
+			if stepsRunningCount > 0 && steps > stepsCompletedCount {
+				containerStatuses = append(containerStatuses, v1.ContainerStatus{
+					Name: step.ID,
+					State: v1.ContainerState{
+						Running: &v1.ContainerStateRunning{},
+					},
+					Image: step.Image,
+				})
+			} else if steps <= stepsCompletedCount {
+				containerStatuses = append(containerStatuses, v1.ContainerStatus{
+					Name: step.ID,
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason:   "Completed",
+							ExitCode: 0,
+						},
+					},
+					Image: step.Image,
+				})
+			}
+		}
+	}
+
+	for _, step := range build.Steps {
+		if step.Name == "init" {
+			continue
+		}
+
+		steps++
+		if steps > stepsCompletedCount+stepsRunningCount {
+			break
+		}
+
+		if stepsRunningCount > 0 && steps > stepsCompletedCount {
+			containerStatuses = append(containerStatuses, v1.ContainerStatus{
+				Name: step.ID,
+				State: v1.ContainerState{
+					Running: &v1.ContainerStateRunning{},
+				},
+				Image: step.Image,
+			})
+		} else if steps <= stepsCompletedCount {
+			containerStatuses = append(containerStatuses, v1.ContainerStatus{
+				Name: step.ID,
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						Reason:   "Completed",
+						ExitCode: 0,
+					},
+				},
+				Image: step.Image,
+			})
+		}
+	}
+
+	for _, secret := range build.Secrets {
+		if secret.Origin.Empty() {
+			continue
+		}
 
 		containerStatuses = append(containerStatuses, v1.ContainerStatus{
 			Name:  secret.Origin.ID,
@@ -569,8 +699,5 @@ func testPodFor(build *pipeline.Build) *v1.Pod {
 		})
 	}
 
-	pod.Spec.Containers = containers
-	pod.Status.ContainerStatuses = containerStatuses
-
-	return pod
+	return containerStatuses
 }

--- a/executor/linux/linux_test.go
+++ b/executor/linux/linux_test.go
@@ -340,54 +340,38 @@ func testSteps(runtime string) *pipeline.Build {
 	return steps.Sanitize(runtime)
 }
 
-// https://github.com/go-vela/worker/blob/main/runtime/kubernetes/kubernetes_test.go#L83
-var _pod = &v1.Pod{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "github-octocat-1",
-		Namespace: "test",
-		Labels: map[string]string{
-			"pipeline": "github-octocat-1",
-		},
-	},
-	TypeMeta: metav1.TypeMeta{
-		APIVersion: "v1",
-		Kind:       "Pod",
-	},
-	Status: v1.PodStatus{
-		Phase: v1.PodRunning,
-		ContainerStatuses: []v1.ContainerStatus{
-			{
-				Name: "step-github-octocat-1-clone",
-				State: v1.ContainerState{
-					Terminated: &v1.ContainerStateTerminated{
-						Reason:   "Completed",
-						ExitCode: 0,
-					},
-				},
-				Image: "target/vela-git:v0.6.0",
-			},
-			{
-				Name: "step-github-octocat-1-echo",
-				State: v1.ContainerState{
-					Terminated: &v1.ContainerStateTerminated{
-						Reason:   "Completed",
-						ExitCode: 0,
-					},
-				},
-				Image: "alpine:latest",
+// testPod is a test helper function to create a Pod
+// type with all fields set to a fake value.
+func testPod(stages bool) *v1.Pod {
+	// https://github.com/go-vela/worker/blob/main/runtime/kubernetes/kubernetes_test.go#L83
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "github-octocat-1",
+			Namespace: "test",
+			Labels: map[string]string{
+				"pipeline": "github-octocat-1",
 			},
 		},
-	},
-	Spec: v1.PodSpec{
-		Containers: []v1.Container{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+		Spec: v1.PodSpec{},
+	}
+
+	if stages {
+		pod.Spec.Containers = []v1.Container{
 			{
-				Name:            "step-github-octocat-1-clone",
+				Name:            "github-octocat-1-clone-clone",
 				Image:           "target/vela-git:v0.6.0",
 				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
 				ImagePullPolicy: v1.PullAlways,
 			},
 			{
-				Name:            "step-github-octocat-1-echo",
+				Name:            "github-octocat-1-echo-echo",
 				Image:           "alpine:latest",
 				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
 				ImagePullPolicy: v1.PullAlways,
@@ -398,42 +382,8 @@ var _pod = &v1.Pod{
 				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
 				ImagePullPolicy: v1.PullAlways,
 			},
-		},
-		HostAliases: []v1.HostAlias{
-			{
-				IP: "127.0.0.1",
-				Hostnames: []string{
-					"postgres.local",
-					"echo.local",
-				},
-			},
-		},
-		Volumes: []v1.Volume{
-			{
-				Name: "github-octocat-1",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
-				},
-			},
-		},
-	},
-}
-
-var _stagePod = &v1.Pod{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "github-octocat-1",
-		Namespace: "test",
-		Labels: map[string]string{
-			"pipeline": "github-octocat-1",
-		},
-	},
-	TypeMeta: metav1.TypeMeta{
-		APIVersion: "v1",
-		Kind:       "Pod",
-	},
-	Status: v1.PodStatus{
-		Phase: v1.PodRunning,
-		ContainerStatuses: []v1.ContainerStatus{
+		}
+		pod.Status.ContainerStatuses = []v1.ContainerStatus{
 			{
 				Name: "github-octocat-1-clone-clone",
 				State: v1.ContainerState{
@@ -454,18 +404,17 @@ var _stagePod = &v1.Pod{
 				},
 				Image: "alpine:latest",
 			},
-		},
-	},
-	Spec: v1.PodSpec{
-		Containers: []v1.Container{
+		}
+	} else { // step
+		pod.Spec.Containers = []v1.Container{
 			{
-				Name:            "github-octocat-1-clone-clone",
+				Name:            "step-github-octocat-1-clone",
 				Image:           "target/vela-git:v0.6.0",
 				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
 				ImagePullPolicy: v1.PullAlways,
 			},
 			{
-				Name:            "github-octocat-1-echo-echo",
+				Name:            "step-github-octocat-1-echo",
 				Image:           "alpine:latest",
 				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
 				ImagePullPolicy: v1.PullAlways,
@@ -476,23 +425,30 @@ var _stagePod = &v1.Pod{
 				WorkingDir:      "/vela/src/github.com/octocat/helloworld",
 				ImagePullPolicy: v1.PullAlways,
 			},
-		},
-		HostAliases: []v1.HostAlias{
+		}
+		pod.Status.ContainerStatuses = []v1.ContainerStatus{
 			{
-				IP: "127.0.0.1",
-				Hostnames: []string{
-					"postgres.local",
-					"echo.local",
+				Name: "step-github-octocat-1-clone",
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						Reason:   "Completed",
+						ExitCode: 0,
+					},
 				},
+				Image: "target/vela-git:v0.6.0",
 			},
-		},
-		Volumes: []v1.Volume{
 			{
-				Name: "github-octocat-1",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{},
+				Name: "step-github-octocat-1-echo",
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						Reason:   "Completed",
+						ExitCode: 0,
+					},
 				},
+				Image: "alpine:latest",
 			},
-		},
-	},
+		}
+	}
+
+	return pod
 }

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -319,7 +319,7 @@ func TestLinux_Secret_exec(t *testing.T) {
 
 			switch test.runtime {
 			case constants.DriverKubernetes:
-				_pod := testPod(false) // TODO: need pipeline-specific pod
+				_pod := testPodFor(p)
 				_runtime, err = kubernetes.NewMock(_pod)
 				if err != nil {
 					t.Errorf("unable to create kubernetes runtime engine: %v", err)

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-vela/worker/internal/message"
 	"github.com/go-vela/worker/runtime"
 	"github.com/go-vela/worker/runtime/docker"
+	"github.com/go-vela/worker/runtime/kubernetes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/urfave/cli/v2"
 )
@@ -317,6 +318,12 @@ func TestLinux_Secret_exec(t *testing.T) {
 			var _runtime runtime.Engine
 
 			switch test.runtime {
+			case constants.DriverKubernetes:
+				// TODO: need pipeline-specific pod
+				_runtime, err = kubernetes.NewMock(_pod)
+				if err != nil {
+					t.Errorf("unable to create kubernetes runtime engine: %v", err)
+				}
 			case constants.DriverDocker:
 				_runtime, err = docker.NewMock()
 				if err != nil {

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -319,7 +319,7 @@ func TestLinux_Secret_exec(t *testing.T) {
 
 			switch test.runtime {
 			case constants.DriverKubernetes:
-				// TODO: need pipeline-specific pod
+				_pod := testPod(false) // TODO: need pipeline-specific pod
 				_runtime, err = kubernetes.NewMock(_pod)
 				if err != nil {
 					t.Errorf("unable to create kubernetes runtime engine: %v", err)


### PR DESCRIPTION
@JordanSussman, @jbrockopp and I worked on adding executor tests that use the kubernetes runtime. You can see the results of that effort in the [executor-k8s-tests](https://github.com/go-vela/worker/compare/executor-k8s-tests) branch. This PR prepares for getting all of those test cases added. This PR:

- add several test helpers for use in generating the `pod` required for testing with the kubernetes runtime:
    - `func testPod(useStages bool) *v1.Pod`
    - `func testPodFor(build *pipeline.Build) *v1.Pod`
    - `func testContainerStatuses(...) []v1.ContainerStatus` _used by `testPod*`_
    - `func countBuildSteps(build *pipeline.Build) int` _used by `testContainerStatuses`_
- initialize the per-subtest k8s `_runtime` instances

For tests that initialize only one k8s runtime instance per test (vs per subtest), I will add that init logic when we add the test cases. Otherwise, the `_kubernetes` var would be flagged as unused.