### PR TITLE
enhance(executor tests): Call k8s SetupMock method after CreateBuild in tests

### DIFF
--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1890,8 +1890,16 @@ func TestLinux_StreamBuild(t *testing.T) {
 				t.Errorf("%s unable to create build: %v", test.name, err)
 			}
 
-			// simulate ExecBuild() which runs concurrently with StreamBuild()
+			// simulate AssembleBuild()/ExecBuild() which run concurrently with StreamBuild()
 			go func() {
+				// This Kubernetes setup would normally be called within AssembleBuild()
+				if test.runtime == constants.DriverKubernetes {
+					err = _runtime.(kubernetes.MockKubernetesRuntime).SetupMock()
+					if err != nil {
+						t.Errorf("Kubernetes runtime SetupMock returned err: %v", err)
+					}
+				}
+
 				if test.earlyBuildDone {
 					// imitate build getting canceled or otherwise finishing before ExecBuild gets called.
 					done()

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1529,6 +1529,14 @@ func TestLinux_ExecBuild(t *testing.T) {
 			// go-vela/server has logic to set it to an expected state.
 			_engine.build.SetStatus("running")
 
+			// Kubernetes runtime needs to set up the Mock after CreateBuild is called
+			if test.runtime == constants.DriverKubernetes {
+				err = _runtime.(kubernetes.MockKubernetesRuntime).SetupMock()
+				if err != nil {
+					t.Errorf("Kubernetes runtime SetupMock returned err: %v", err)
+				}
+			}
+
 			err = _engine.ExecBuild(context.Background())
 
 			if test.failure {
@@ -2090,6 +2098,14 @@ func TestLinux_DestroyBuild(t *testing.T) {
 			err = _engine.CreateBuild(context.Background())
 			if err != nil {
 				t.Errorf("%s unable to create build: %v", test.name, err)
+			}
+
+			// Kubernetes runtime needs to set up the Mock after CreateBuild is called
+			if test.runtime == constants.DriverKubernetes {
+				err = _runtime.(kubernetes.MockKubernetesRuntime).SetupMock()
+				if err != nil {
+					t.Errorf("Kubernetes runtime SetupMock returned err: %v", err)
+				}
 			}
 
 			err = _engine.DestroyBuild(context.Background())

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -235,6 +235,14 @@ func TestLinux_Secret_delete(t *testing.T) {
 			// add init container info to client
 			_ = _engine.CreateBuild(context.Background())
 
+			// Kubernetes runtime needs to set up the Mock after CreateBuild is called
+			if test.runtime.Driver() == constants.DriverKubernetes {
+				err = _engine.Runtime.(kubernetes.MockKubernetesRuntime).SetupMock()
+				if err != nil {
+					t.Errorf("Kubernetes runtime SetupMock returned err: %v", err)
+				}
+			}
+
 			_engine.steps.Store(test.container.ID, test.step)
 
 			err = _engine.secret.destroy(context.Background(), test.container)
@@ -348,6 +356,14 @@ func TestLinux_Secret_exec(t *testing.T) {
 
 			// add init container info to client
 			_ = _engine.CreateBuild(context.Background())
+
+			// Kubernetes runtime needs to set up the Mock after CreateBuild is called
+			if test.runtime == constants.DriverKubernetes {
+				err = _runtime.(kubernetes.MockKubernetesRuntime).SetupMock()
+				if err != nil {
+					t.Errorf("Kubernetes runtime SetupMock returned err: %v", err)
+				}
+			}
 
 			err = _engine.secret.exec(context.Background(), &p.Secrets)
 
@@ -622,6 +638,14 @@ func TestLinux_Secret_stream(t *testing.T) {
 
 			// add init container info to client
 			_ = _engine.CreateBuild(context.Background())
+
+			// Kubernetes runtime needs to set up the Mock after CreateBuild is called
+			if test.runtime.Driver() == constants.DriverKubernetes {
+				err = _engine.Runtime.(kubernetes.MockKubernetesRuntime).SetupMock()
+				if err != nil {
+					t.Errorf("Kubernetes runtime SetupMock returned err: %v", err)
+				}
+			}
 
 			err = _engine.secret.stream(context.Background(), test.container)
 

--- a/runtime/kubernetes/mock.go
+++ b/runtime/kubernetes/mock.go
@@ -90,8 +90,16 @@ func NewMock(_pod *v1.Pod, opts ...ClientOpt) (*client, error) {
 //
 // This interface is intended for running tests only.
 type MockKubernetesRuntime interface {
+	SetupMock() error
 	MarkPodTrackerReady()
 	SimulateResync(*v1.Pod)
+}
+
+// SetupMock allows the Kubernetes runtime to perform additional Mock-related config.
+// Many tests should call this right after they call runtime.SetupBuild (or executor.CreateBuild).
+func (c *client) SetupMock() error {
+	// This assumes that c.Pod.ObjectMeta.Namespace and c.Pod.ObjectMeta.Name are filled in.
+	return c.PodTracker.setupMockFor(c.Pod)
 }
 
 // MarkPodTrackerReady signals that PodTracker has been setup with ContainerTrackers.

--- a/runtime/kubernetes/mock.go
+++ b/runtime/kubernetes/mock.go
@@ -4,14 +4,17 @@
 
 package kubernetes
 
+// Everything in this file should only be used in test code.
+// It is exported for use in tests of other packages.
+
 import (
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
 	velav1alpha1 "github.com/go-vela/worker/runtime/kubernetes/apis/vela/v1alpha1"
 	fakeVelaK8sClient "github.com/go-vela/worker/runtime/kubernetes/generated/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
 )
 
 // NewMock returns an Engine implementation that
@@ -97,6 +100,8 @@ type MockKubernetesRuntime interface {
 
 // SetupMock allows the Kubernetes runtime to perform additional Mock-related config.
 // Many tests should call this right after they call runtime.SetupBuild (or executor.CreateBuild).
+//
+// This function is intended for running tests only.
 func (c *client) SetupMock() error {
 	// This assumes that c.Pod.ObjectMeta.Namespace and c.Pod.ObjectMeta.Name are filled in.
 	return c.PodTracker.setupMockFor(c.Pod)

--- a/runtime/kubernetes/pod_tracker.go
+++ b/runtime/kubernetes/pod_tracker.go
@@ -251,14 +251,24 @@ func mockPodTracker(log *logrus.Entry, clientset kubernetes.Interface, pod *v1.P
 		return nil, err
 	}
 
-	// init containerTrackers as well
-	tracker.TrackContainers(pod.Spec.Containers)
-
-	// pre-populate the podInformer cache
-	err = tracker.podInformer.Informer().GetIndexer().Add(pod)
+	err = tracker.setupMockFor(pod)
 	if err != nil {
 		return nil, err
 	}
 
 	return tracker, err
+}
+
+// setupMockFor initializes the podTracker's internal caches with the given pod.
+func (p *podTracker) setupMockFor(pod *v1.Pod) error {
+	// init containerTrackers as well
+	p.TrackContainers(pod.Spec.Containers)
+
+	// pre-populate the podInformer cache
+	err := p.podInformer.Informer().GetIndexer().Add(pod)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
@JordanSussman, @jbrockopp and I worked on adding executor tests that use the kubernetes runtime. You can see the results of that effort in the [executor-k8s-tests](https://github.com/go-vela/worker/compare/executor-k8s-tests) branch. This PR prepares for getting all of those test cases added. I plan to add the test cases separately once more of the changes needed to manage the k8s mocks are included in the executor tests.

The Kubernetes runtime normally does some setup during AssembleBuild: We pre-populate the cache of the Mock PodTracker which watches the k8s API for changes to the pod (where build:pod maps 1:1). In any tests that call CreateBuild, we need to trigger that setup for the Mock after CreateBuild is called. So, we export a new `SetupMock` function that the executor tests can use to do this at the right point.