### PR TITLE
enhance(executor tests): Manage k8s mocks for Executor exec tests

### DIFF
--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1570,7 +1570,9 @@ func TestLinux_ExecBuild(t *testing.T) {
 						if err != nil {
 							t.Errorf("%s - failed to simulate pod update: %s", test.name, err)
 						}
-						// TODO: maybe add a pause here
+
+						// simulate exec build duration
+						time.Sleep(100 * time.Microsecond)
 					}
 				}()
 			}

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1940,6 +1940,9 @@ func TestLinux_StreamBuild(t *testing.T) {
 					if err != nil {
 						t.Errorf("Kubernetes runtime SetupMock returned err: %v", err)
 					}
+
+					// Runtime.StreamBuild calls PodTracker.Start after the PodTracker is marked Ready
+					_runtime.(kubernetes.MockKubernetesRuntime).MarkPodTrackerReady()
 				}
 
 				if test.earlyBuildDone {

--- a/executor/linux/secret_test.go
+++ b/executor/linux/secret_test.go
@@ -365,6 +365,8 @@ func TestLinux_Secret_exec(t *testing.T) {
 				if err != nil {
 					t.Errorf("Kubernetes runtime SetupMock returned err: %v", err)
 				}
+
+				go _runtime.(kubernetes.MockKubernetesRuntime).SimulateResync(nil)
 			}
 
 			err = _engine.secret.exec(context.Background(), &p.Secrets)

--- a/runtime/kubernetes/build.go
+++ b/runtime/kubernetes/build.go
@@ -212,7 +212,7 @@ func (c *client) AssembleBuild(ctx context.Context, b *pipeline.Build) error {
 		}
 	}
 
-	// setup containerTeachers now that all containers are defined.
+	// setup containerTrackers now that all containers are defined.
 	c.PodTracker.TrackContainers(c.Pod.Spec.Containers)
 
 	// send signal to StreamBuild now that PodTracker is ready to be started.

--- a/runtime/kubernetes/mock.go
+++ b/runtime/kubernetes/mock.go
@@ -8,6 +8,8 @@ package kubernetes
 // It is exported for use in tests of other packages.
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -95,7 +97,9 @@ func NewMock(_pod *v1.Pod, opts ...ClientOpt) (*client, error) {
 type MockKubernetesRuntime interface {
 	SetupMock() error
 	MarkPodTrackerReady()
+	StartPodTracker(context.Context)
 	SimulateResync(*v1.Pod)
+	SimulateStatusUpdate(*v1.Pod, []v1.ContainerStatus) error
 }
 
 // SetupMock allows the Kubernetes runtime to perform additional Mock-related config.
@@ -114,6 +118,12 @@ func (c *client) MarkPodTrackerReady() {
 	close(c.PodTracker.Ready)
 }
 
+// StartPodTracker tells the podTracker it can start populating the cache.
+// This is only here for tests.
+func (c *client) StartPodTracker(ctx context.Context) {
+	c.PodTracker.Start(ctx)
+}
+
 // SimulateResync simulates an resync where the PodTracker refreshes its cache.
 // This resync is from oldPod to runtime.Pod. If nil, oldPod defaults to runtime.Pod.
 //
@@ -128,4 +138,22 @@ func (c *client) SimulateResync(oldPod *v1.Pod) {
 
 	// simulate a re-sync/PodUpdate event
 	c.PodTracker.HandlePodUpdate(oldPod, c.Pod)
+}
+
+// SimulateUpdate simulates an update event from the k8s API.
+// This is only here for tests.
+func (c *client) SimulateStatusUpdate(pod *v1.Pod, containerStatuses []v1.ContainerStatus) error {
+	// We have to have a full copy here because the k8s client Mock
+	// replaces the pod it is storing, it does not just update the status.
+	updatedPod := pod.DeepCopy()
+	updatedPod.Status.ContainerStatuses = containerStatuses
+
+	_, err := c.Kubernetes.CoreV1().Pods(pod.GetNamespace()).
+		UpdateStatus(
+			context.Background(),
+			updatedPod,
+			metav1.UpdateOptions{},
+		)
+
+	return err
 }

--- a/runtime/kubernetes/mock.go
+++ b/runtime/kubernetes/mock.go
@@ -86,7 +86,8 @@ func NewMock(_pod *v1.Pod, opts ...ClientOpt) (*client, error) {
 
 	c.PodTracker = tracker
 
-	// The test is responsible for calling c.PodTracker.Start() if needed
+	// The test is responsible for calling c.PodTracker.Start(ctx) if needed.
+	// In some cases it is more convenient to call c.(MockKubernetesRuntime).StartPodTracker(ctx)
 
 	return c, nil
 }
@@ -119,7 +120,8 @@ func (c *client) MarkPodTrackerReady() {
 }
 
 // StartPodTracker tells the podTracker it can start populating the cache.
-// This is only here for tests.
+//
+// This function is intended for running tests only.
 func (c *client) StartPodTracker(ctx context.Context) {
 	c.PodTracker.Start(ctx)
 }
@@ -141,7 +143,8 @@ func (c *client) SimulateResync(oldPod *v1.Pod) {
 }
 
 // SimulateUpdate simulates an update event from the k8s API.
-// This is only here for tests.
+//
+// This function is intended for running tests only.
 func (c *client) SimulateStatusUpdate(pod *v1.Pod, containerStatuses []v1.ContainerStatus) error {
 	// We have to have a full copy here because the k8s client Mock
 	// replaces the pod it is storing, it does not just update the status.


### PR DESCRIPTION
@JordanSussman, @jbrockopp and I worked on adding executor tests that use the kubernetes runtime. You can see the results of that effort in the [executor-k8s-tests](https://github.com/go-vela/worker/compare/executor-k8s-tests) branch. This PR prepares for getting all of those test cases added. I plan to add the test cases separately once more of the changes needed to manage the k8s mocks are included in the executor tests.

This PR adds another part of the k8s mock management logic. In order to make the mocks during the ExecBuild test, we need 2 more exported methods in the kubernetes runtime:
- `StartPodTracker`
- `SimulateStatusUpdate`

K8s runtime tests have to manage starting the PodTracker which subscribes to a stream is k8s events. That is not part of the runtime interface, however, so we need to export a `StartPodTracker` method that the executor tests can use.

There are three kinds of k8s events that the k8s runtime watches for: changes to the pod itself, changes to the status of the pod, and generic k8s events. We use `SimulateResync` (introduced in a previous PR) to trigger events related to updating the pod itself. "Status" includes when the pod or a container is ready, running, terminated, etc. This is what `SimulateStatusUpdate` handles. I'm not using the third kind of generic k8s event yet in the kubernetes runtime. Once added, I don't think the executor tests will need to trigger that kind of event.

Finally we add calls to these and other mock methods in the ExecBuild test (to simulate execution) and the secret.exec tests. The StreamBuild test does not need to call `StartPodTracker` because that gets called as part of Runtime.StreamBuild. Instead, that test just needed a call to `MarkPodTrackerReady` (added in a previous PR) so that the runtime can make that call.

I also adjusted a few comments to fix a typo and suggest using the new mock helper methods.