### PR TITLE
enhance(executor tests):  Manage k8s mocks for Executor AssembleBuild test

### DIFF
--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1369,7 +1369,9 @@ func TestLinux_AssembleBuild(t *testing.T) {
 						if err != nil {
 							t.Errorf("%s - failed to simulate pod update: %s", test.name, err)
 						}
-						// TODO: maybe add a pause here
+
+						// simulate exec build duration
+						time.Sleep(100 * time.Microsecond)
 					}
 				}()
 			}

--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1350,28 +1350,12 @@ func TestLinux_AssembleBuild(t *testing.T) {
 					// Now wait until the pod is created at the end of runtime.AssembleBuild.
 					_mockRuntime.WaitForPodCreate(_pod.GetNamespace(), _pod.GetName())
 
-					var stepsRunningCount int
-
-					percents := []int{0, 0, 50, 100}
-					lastIndex := len(percents) - 1
-					for index, stepsCompletedPercent := range percents {
-						if index == 0 || index == lastIndex {
-							stepsRunningCount = 0
-						} else {
-							stepsRunningCount = 1
-						}
-
-						err := _mockRuntime.SimulateStatusUpdate(_pod,
-							testContainerStatuses(
-								_pipeline, true, stepsRunningCount, stepsCompletedPercent,
-							),
-						)
-						if err != nil {
-							t.Errorf("%s - failed to simulate pod update: %s", test.name, err)
-						}
-
-						// simulate exec build duration
-						time.Sleep(100 * time.Microsecond)
+					// Mark services running and secrets as completed, but no steps have started.
+					err := _mockRuntime.SimulateStatusUpdate(_pod,
+						testContainerStatuses(_pipeline, true, 0, 0),
+					)
+					if err != nil {
+						t.Errorf("%s - failed to simulate pod update: %s", test.name, err)
 					}
 				}()
 			}

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -5,7 +5,6 @@
 package kubernetes
 
 import (
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -13,6 +12,7 @@ import (
 
 	velav1alpha1 "github.com/go-vela/worker/runtime/kubernetes/apis/vela/v1alpha1"
 	velaK8sClient "github.com/go-vela/worker/runtime/kubernetes/generated/clientset/versioned"
+	"github.com/sirupsen/logrus"
 )
 
 type config struct {


### PR DESCRIPTION
@JordanSussman, @jbrockopp and I worked on adding executor tests that use the kubernetes runtime. You can see the results of that effort in the [executor-k8s-tests](https://github.com/go-vela/worker/compare/executor-k8s-tests) branch. This PR prepares for getting all of those test cases added. I plan to add the test cases separately in a few PRs after this PR is merged.

This PR adds another part of the k8s mock management logic. In order to make the mocks during the AssembleBui9ld test, we need 2 more exported methods in the kubernetes runtime:
- `WaitForPodTrackerReady`
- `WaitForPodCreate`

K8s runtime tests have to wait for certain events (esp `<-c.PodTracker.Ready`) before adjusting the k8s mock at the appropriate points. The things needed to do that are not part of the runtime interface, however, so we need to export the `WaitForPod*` methods that the executor tests can use.

Also, I reordered one of the imports in `runtime/kubernetes/kubernetes.go`. Not really related, but it's been annoying me, and it's very small, so I fixed it. 😄