### PR TITLE
feat(mock): add support for register endpoint

### DIFF
--- a/api/register.go
+++ b/api/register.go
@@ -26,6 +26,10 @@ import (
 //     description: Successfully passed token to worker
 //     schema:
 //       type: string
+//   '401':
+//     description: No token was passed
+//     schema:
+//       "$ref": "#/definitions/Error"
 //   '500':
 //     description: Unable to pass token to worker
 //     schema:
@@ -59,7 +63,8 @@ func Register(c *gin.Context) {
 	// retrieve auth token from header
 	token, err := token.Retrieve(c.Request)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, err)
+		// an error occurs when no token was passed
+		c.JSON(http.StatusUnauthorized, err)
 		return
 	}
 

--- a/mock/worker/register.go
+++ b/mock/worker/register.go
@@ -16,7 +16,7 @@ import (
 func postRegister(c *gin.Context) {
 	token := c.Request.Header.Get("Authorization")
 	if len(token) == 0 {
-		c.JSON(http.StatusInternalServerError, "no token provided in Authorization header")
+		c.JSON(http.StatusUnauthorized, "no token provided in Authorization header")
 	}
 
 	c.JSON(http.StatusOK, "successfully passed token to worker")

--- a/mock/worker/register.go
+++ b/mock/worker/register.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package worker
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// postRegister returns mock JSON for a http POST.
+//
+// Do not pass an auth token to fail the request.
+func postRegister(c *gin.Context) {
+	token := c.Request.Header.Get("Authorization")
+	if len(token) == 0 {
+		c.JSON(http.StatusInternalServerError, "no token provided in Authorization header")
+	}
+
+	c.JSON(http.StatusOK, "successfully passed token to worker")
+}

--- a/mock/worker/server.go
+++ b/mock/worker/server.go
@@ -31,5 +31,8 @@ func FakeHandler() http.Handler {
 	// mock endpoints for repo calls
 	e.GET("/api/v1/executors/:executor/repo", getRepo)
 
+	// mock endpoint for register call
+	e.POST("/register", postRegister)
+
 	return e
 }


### PR DESCRIPTION
- adds mock for /register
- fixes return code when no token was passed (4xx instead of 5xx)