### PR TITLE
feat!: Use queue Item.ItemVersion field to fail stale builds

### DIFF
--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -79,7 +79,9 @@ func (w *Worker) exec(index int) error {
 		logrus.Errorf("Failing stale queued build due to wrong item version: want %d, got %d", types.ItemVersion, item.ItemVersion)
 
 		build := item.Build
-		build.SetStatus(constants.StatusFailure)
+		build.SetError("Unable to process stale build (queued before Vela upgrade/downgrade).")
+		build.SetStatus(constants.StatusError)
+		build.SetFinished(time.Now().UTC().Unix())
 
 		_, _, err := w.VelaClient.Build.Update(item.Repo.GetOrg(), item.Repo.GetName(), build)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-vela/sdk-go v0.19.2
 	github.com/go-vela/server v0.19.3-0.20230510141710-f99a894333d4
-	github.com/go-vela/types v0.19.2
+	github.com/go-vela/types v0.19.3-0.20230523200921-35a0d5fc088c
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/go-cmp v0.5.9
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/go-vela/sdk-go v0.19.2 h1:bEMnEnEZxI27ZCjFx5fNRFc0EYHr2NsR2jb//0J5SJk
 github.com/go-vela/sdk-go v0.19.2/go.mod h1:p0WwKyBLslyhPjSQnA78SVZpLDkOL/P030BtzdRDjtE=
 github.com/go-vela/server v0.19.3-0.20230510141710-f99a894333d4 h1:hAj76WkNt+CZfkionu86xlpM3YpupZkX1OWHzWbeEpA=
 github.com/go-vela/server v0.19.3-0.20230510141710-f99a894333d4/go.mod h1:N6ej04/c6kc/0sJK15jCLr3Au9L9Zs9TjcMtkJoyJx8=
-github.com/go-vela/types v0.19.2 h1:xU61CX2jdMuBCtLOg8a7Z2aEWYM1zZt37Ygx1oHGbjM=
-github.com/go-vela/types v0.19.2/go.mod h1:ZvDjYCKU36yJS3sLxPLCny/HLF1U6YtlOienzv/cXB4=
+github.com/go-vela/types v0.19.3-0.20230523200921-35a0d5fc088c h1:eAApIK5e5MxFF8RzZAFsvTSdwq/AzdUrdhJHOGQ0ILc=
+github.com/go-vela/types v0.19.3-0.20230523200921-35a0d5fc088c/go.mod h1:0lsuPfGyVyTWJSi2h3NS6uaEW6DgnFvIzaZu1sXYKrs=
 github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
 github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=


### PR DESCRIPTION
Part of https://github.com/go-vela/community/issues/811
Depends on https://github.com/go-vela/types/pull/292

This should allow the worker to invalidate stale queued builds. A stale build is a build that was queued before a Vela upgrade or downgrade if the two Vela versions do not share the same queue ItemVersion.

In the future, we could do something even nicer and ask the server to recompile and requeue the build.

Closes https://github.com/go-vela/community/issues/811