### PR TITLE
enhance(log): no library log return for update calls

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -226,7 +226,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		// send API call to update the logs for the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-		_log, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), c.init.Number, _log)
+		_, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), c.init.Number, _log)
 		if err != nil {
 			c.Logger.Errorf("unable to upload %s logs: %v", c.init.Name, err)
 		}

--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -280,7 +280,7 @@ func (s *secretSvc) stream(ctx context.Context, ctn *pipeline.Container) error {
 		// send API call to update the logs for the service
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
-		_log, _, err = s.client.Vela.Log.UpdateStep(s.client.repo.GetOrg(), s.client.repo.GetName(), s.client.build.GetNumber(), ctn.Number, _log)
+		_, err = s.client.Vela.Log.UpdateStep(s.client.repo.GetOrg(), s.client.repo.GetName(), s.client.build.GetNumber(), ctn.Number, _log)
 		if err != nil {
 			logger.Errorf("unable to upload container logs: %v", err)
 		}
@@ -316,7 +316,7 @@ func (s *secretSvc) stream(ctx context.Context, ctn *pipeline.Container) error {
 			//
 			// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
 			//nolint:contextcheck // ignore passing context
-			_log, _, err = s.client.Vela.Log.UpdateStep(s.client.repo.GetOrg(), s.client.repo.GetName(), s.client.build.GetNumber(), s.client.init.Number, _log)
+			_, err = s.client.Vela.Log.UpdateStep(s.client.repo.GetOrg(), s.client.repo.GetName(), s.client.build.GetNumber(), s.client.init.Number, _log)
 			if err != nil {
 				return err
 			}

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -207,7 +207,7 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
 		//nolint:contextcheck // ignore passing context
-		_, _, err = c.Vela.Log.UpdateService(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
+		_, err = c.Vela.Log.UpdateService(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
 		if err != nil {
 			logger.Errorf("unable to upload container logs: %v", err)
 		}
@@ -266,7 +266,7 @@ func (c *client) StreamService(ctx context.Context, ctn *pipeline.Container) err
 					// send API call to append the logs for the service
 					//
 					// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateService
-					_log, _, err = c.Vela.Log.UpdateService(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
+					_, err = c.Vela.Log.UpdateService(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
 					if err != nil {
 						logger.Error(err)
 					}

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -250,7 +250,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
 		//nolint:contextcheck // ignore passing context
-		_, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
+		_, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
 		if err != nil {
 			logger.Errorf("unable to upload container logs: %v", err)
 		}
@@ -314,7 +314,7 @@ func (c *client) StreamStep(ctx context.Context, ctn *pipeline.Container) error 
 					// send API call to append the logs for the step
 					//
 					// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogStep.UpdateStep
-					_log, _, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
+					_, err = c.Vela.Log.UpdateStep(c.repo.GetOrg(), c.repo.GetName(), c.build.GetNumber(), ctn.Number, _log)
 					if err != nil {
 						logger.Error(err)
 					}

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/docker/docker v20.10.24+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/gin-gonic/gin v1.9.0
-	github.com/go-vela/sdk-go v0.19.3-0.20230525152744-4c6fc715258c
-	github.com/go-vela/server v0.19.3-0.20230523191014-5a9a92d279e0
+	github.com/go-vela/sdk-go v0.19.3-0.20230609172535-4dfd42c3640a
+	github.com/go-vela/server v0.19.3-0.20230609145007-f8c795f7aa03
 	github.com/go-vela/types v0.19.3-0.20230523200921-35a0d5fc088c
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -143,10 +143,10 @@ github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91
 github.com/go-playground/validator/v10 v10.11.2 h1:q3SHpufmypg+erIExEKUmsgmhDTyhcJ38oeKGACXohU=
 github.com/go-playground/validator/v10 v10.11.2/go.mod h1:NieE624vt4SCTJtD87arVLvdmjPAeV8BQlHtMnw9D7s=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
-github.com/go-vela/sdk-go v0.19.3-0.20230525152744-4c6fc715258c h1:2GV5t+AOyMYIoyFvzOFCT1dt08KROzaUozK1oW6Q4p0=
-github.com/go-vela/sdk-go v0.19.3-0.20230525152744-4c6fc715258c/go.mod h1:0XTE3DHG5B872POEhKJ3kZzL8ZvR1jAJSeakeJgjfCM=
-github.com/go-vela/server v0.19.3-0.20230523191014-5a9a92d279e0 h1:jyNJ1YdYj0YBRcwzyab8yZWBjGt543ATp/eftgPZBoA=
-github.com/go-vela/server v0.19.3-0.20230523191014-5a9a92d279e0/go.mod h1:sjfqYOyuXG7uqgeQF03URz7GGNjVE+JNIhkGK00eT9o=
+github.com/go-vela/sdk-go v0.19.3-0.20230609172535-4dfd42c3640a h1:8ZpMB3fYAyRGKPBq0Y8NltuDjzaD0k8oISjkP0fBP1o=
+github.com/go-vela/sdk-go v0.19.3-0.20230609172535-4dfd42c3640a/go.mod h1:4vnf8+6RVvWmMLaivX1okkA8s2YJxTcqFjIv+z3r5C0=
+github.com/go-vela/server v0.19.3-0.20230609145007-f8c795f7aa03 h1:Vi1y5faOZ5CaCjCTRfc45z+BpR5JgMpLyIxmy7pSgqE=
+github.com/go-vela/server v0.19.3-0.20230609145007-f8c795f7aa03/go.mod h1:b520o4N7ss4kHATH291Ui1LHwuC0qEgJgg/Jab6yPIQ=
 github.com/go-vela/types v0.19.3-0.20230523200921-35a0d5fc088c h1:eAApIK5e5MxFF8RzZAFsvTSdwq/AzdUrdhJHOGQ0ILc=
 github.com/go-vela/types v0.19.3-0.20230523200921-35a0d5fc088c/go.mod h1:0lsuPfGyVyTWJSi2h3NS6uaEW6DgnFvIzaZu1sXYKrs=
 github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=

--- a/internal/step/snapshot.go
+++ b/internal/step/snapshot.go
@@ -107,7 +107,7 @@ func SnapshotInit(ctn *pipeline.Container, b *library.Build, c *vela.Client, l *
 		// send API call to update the logs for the step
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela?tab=doc#LogService.UpdateStep
-		_, _, err = c.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), s.GetNumber(), lg)
+		_, err = c.Log.UpdateStep(r.GetOrg(), r.GetName(), b.GetNumber(), s.GetNumber(), lg)
 		if err != nil {
 			l.Errorf("unable to upload step logs: %v", err)
 		}


### PR DESCRIPTION
Ref: https://github.com/go-vela/server/pull/879 and https://github.com/go-vela/sdk-go/pull/242

No longer returning the log with update calls, so we can remove that extra `_log` assignment at a few points in the code base. Max log size will be checked using the in-memory value of `_log` rather than what is returned from the server. Provided the call was successful, it should be the exact same value.