### PR TITLE
fix(exec): use exec client when updating build after failed item version check

### DIFF
--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -106,7 +106,7 @@ func (w *Worker) exec(index int, config *library.Worker) error {
 		build.SetStatus(constants.StatusError)
 		build.SetFinished(time.Now().UTC().Unix())
 
-		_, _, err := w.VelaClient.Build.Update(item.Repo.GetOrg(), item.Repo.GetName(), build)
+		_, _, err := execBuildClient.Build.Update(item.Repo.GetOrg(), item.Repo.GetName(), build)
 		if err != nil {
 			logrus.Errorf("Unable to set build status to %s: %s", constants.StatusFailure, err)
 			return err


### PR DESCRIPTION
`w.VelaClient` does not have the right auth scopes for updating a build, but the `execBuildClient` does. 