### PR TITLE
enhance(init): display basic worker info in init step logs

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -98,6 +98,9 @@ func (c *client) PlanBuild(ctx context.Context) error {
 		return err
 	}
 
+	// put worker information into init logs
+	_log.AppendData([]byte(fmt.Sprintf("> Worker Information:\n Host: %s\n Version: %s\n Runtime: %s\n", c.Hostname, c.Version, c.Runtime.Driver())))
+
 	// defer taking a snapshot of the init step
 	//
 	// https://pkg.go.dev/github.com/go-vela/worker/internal/step#SnapshotInit


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/125.

While we can leverage the hover display on the build nav bar to check the worker that ran a specific build, I've found this to be a bit finicky and more difficult to analyze older builds. Throwing some basic worker / runtime info in the init step seems like a fairly simple win. 

I can also foresee this change being temporary if/when [the init step overhaul proposal](https://github.com/go-vela/community/pull/789) gets off the ground and running.