### PR TITLE
fix(queue): avoid worker restart on queue fail

### DIFF
--- a/cmd/vela-worker/operate.go
+++ b/cmd/vela-worker/operate.go
@@ -65,12 +65,14 @@ func (w *Worker) operate(ctx context.Context) error {
 	// https://pkg.go.dev/github.com/go-vela/server/queue?tab=doc#New
 	w.Queue, err = queue.New(w.Config.Queue)
 	if err != nil {
+		logrus.Error("queue setup failed")
+
 		registryWorker.SetStatus(constants.WorkerStatusError)
 		_, resp, logErr := w.VelaClient.Worker.Update(registryWorker.GetHostname(), registryWorker)
 
 		if resp == nil {
 			// log the error instead of returning so the operation doesn't block worker deployment
-			logrus.Error("status update response is nil")
+			logrus.Error("worker status update response is nil")
 		}
 
 		if logErr != nil {


### PR DESCRIPTION
this should make it nicer for admins in the instance there is a temporary issue on the queue availability. previously, this could cause the worker to become unregistered resulting in admin work. this change will not error the worker (and cause it to restart). it will log the error and wait for the configured queue timeout before continuing business as usual.