### PR TITLE
feat: specify which privileged image is being pulled for denied build

### DIFF
--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -268,6 +268,14 @@ func (w *Worker) exec(index int, config *library.Worker) error {
 		return nil
 	}
 
+	logger.Info("assembling build")
+	// assemble the build with the executor
+	err = _executor.AssembleBuild(timeoutCtx)
+	if err != nil {
+		logger.Errorf("unable to assemble build: %v", err)
+		return nil
+	}
+
 	// add StreamBuild goroutine to WaitGroup
 	wg.Add(1)
 
@@ -281,14 +289,6 @@ func (w *Worker) exec(index int, config *library.Worker) error {
 			logger.Errorf("unable to stream build logs: %v", err)
 		}
 	}()
-
-	logger.Info("assembling build")
-	// assemble the build with the executor
-	err = _executor.AssembleBuild(timeoutCtx)
-	if err != nil {
-		logger.Errorf("unable to assemble build: %v", err)
-		return nil
-	}
 
 	logger.Info("executing build")
 	// execute the build with the executor

--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -268,14 +268,6 @@ func (w *Worker) exec(index int, config *library.Worker) error {
 		return nil
 	}
 
-	logger.Info("assembling build")
-	// assemble the build with the executor
-	err = _executor.AssembleBuild(timeoutCtx)
-	if err != nil {
-		logger.Errorf("unable to assemble build: %v", err)
-		return nil
-	}
-
 	// add StreamBuild goroutine to WaitGroup
 	wg.Add(1)
 
@@ -289,6 +281,14 @@ func (w *Worker) exec(index int, config *library.Worker) error {
 			logger.Errorf("unable to stream build logs: %v", err)
 		}
 	}()
+
+	logger.Info("assembling build")
+	// assemble the build with the executor
+	err = _executor.AssembleBuild(timeoutCtx)
+	if err != nil {
+		logger.Errorf("unable to assemble build: %v", err)
+		return nil
+	}
 
 	logger.Info("executing build")
 	// execute the build with the executor

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -370,7 +370,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		// assume no privileged images are in use
 		containsPrivilegedImages := false
-		privImage := []string{}
+		privImages := []string{}
 
 		// verify all pipeline containers
 		for _, container := range containers {
@@ -411,7 +411,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 				if privileged {
 					// pipeline contains at least one privileged image
 					containsPrivilegedImages = privileged
-					privImage = append(privImage, container.Image)
+					privImages = append(privImages, container.Image)
 				}
 			}
 
@@ -424,7 +424,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		// ensure pipelines containing privileged images are only permitted to run by trusted repos
 		if (containsPrivilegedImages) && !(c.repo != nil && c.repo.GetTrusted()) {
 			// update error including privileged image
-			c.err = fmt.Errorf("unable to assemble build. pipeline contains privileged images and repo is not trusted. privileged image: %v", privImage)
+			c.err = fmt.Errorf("unable to assemble build. pipeline contains privileged images and repo is not trusted. privileged image: %v", privImages)
 
 			// update the init log with image info
 			//

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -370,7 +370,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		// assume no privileged images are in use
 		containsPrivilegedImages := false
-		privImage := []string{""}
+		privImage := []string{}
 
 		// verify all pipeline containers
 		for _, container := range containers {

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -370,7 +370,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		// assume no privileged images are in use
 		containsPrivilegedImages := false
-		privImage := ""
+		privImage := []string{""}
 
 		// verify all pipeline containers
 		for _, container := range containers {
@@ -411,7 +411,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 				if privileged {
 					// pipeline contains at least one privileged image
 					containsPrivilegedImages = privileged
-					privImage = container.Image
+					privImage = append(privImage, container.Image)
 				}
 			}
 
@@ -424,7 +424,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		// ensure pipelines containing privileged images are only permitted to run by trusted repos
 		if (containsPrivilegedImages) && !(c.repo != nil && c.repo.GetTrusted()) {
 			// update error including privileged image
-			c.err = fmt.Errorf("unable to assemble build. pipeline contains privileged images and repo is not trusted. privileged image: %s", privImage)
+			c.err = fmt.Errorf("unable to assemble build. pipeline contains privileged images and repo is not trusted. privileged image: %v", privImage)
 
 			// update the init log with image info
 			//

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -370,6 +370,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		// assume no privileged images are in use
 		containsPrivilegedImages := false
+		privImage := ""
 
 		// verify all pipeline containers
 		for _, container := range containers {
@@ -410,6 +411,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 				if privileged {
 					// pipeline contains at least one privileged image
 					containsPrivilegedImages = privileged
+					privImage = container.Image
 				}
 			}
 
@@ -422,7 +424,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		// ensure pipelines containing privileged images are only permitted to run by trusted repos
 		if (containsPrivilegedImages) && !(c.repo != nil && c.repo.GetTrusted()) {
 			// update error
-			c.err = fmt.Errorf("unable to assemble build. pipeline contains privileged images and repo is not trusted")
+			c.err = fmt.Errorf("unable to assemble build. pipeline contains privileged images and repo is not trusted. privileged image: %s", privImage)
 
 			// update the init log with image info
 			//

--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -423,7 +423,7 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 
 		// ensure pipelines containing privileged images are only permitted to run by trusted repos
 		if (containsPrivilegedImages) && !(c.repo != nil && c.repo.GetTrusted()) {
-			// update error
+			// update error including privileged image
 			c.err = fmt.Errorf("unable to assemble build. pipeline contains privileged images and repo is not trusted. privileged image: %s", privImage)
 
 			// update the init log with image info


### PR DESCRIPTION
When the `VELA_EXECUTOR_ENFORCE_TRUSTED_REPOS` has been enabled, and an untrusted repo has been denied a build, the resulting error is

`error:build denied, repo must be trusted in order to run privileged images`

It would be convenient if the error specified which image is privileged.


The changes in this PR capture the last privileged image and returns that in the error message.