### PR TITLE
fix: use build id to populate RunningBuildIDs

### DIFF
--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -212,7 +212,7 @@ func (w *Worker) exec(index int, config *library.Worker) error {
 		w.RunningBuildIDsMutex.Lock()
 
 		for i, v := range w.RunningBuildIDs {
-			if v == strconv.Itoa(item.Build.GetNumber()) {
+			if v == strconv.FormatInt(item.Build.GetID(), 10) {
 				w.RunningBuildIDs = append(w.RunningBuildIDs[:i], w.RunningBuildIDs[i+1:]...)
 			}
 		}

--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -106,7 +106,7 @@ func (w *Worker) exec(index int, config *library.Worker) error {
 	// lock and append the build to the RunningBuildIDs list
 	w.RunningBuildIDsMutex.Lock()
 
-	w.RunningBuildIDs = append(w.RunningBuildIDs, strconv.Itoa(item.Build.GetNumber()))
+	w.RunningBuildIDs = append(w.RunningBuildIDs, strconv.Itoa(item.Build.GetID()))
 
 	config.SetRunningBuildIDs(w.RunningBuildIDs)
 

--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -106,7 +106,7 @@ func (w *Worker) exec(index int, config *library.Worker) error {
 	// lock and append the build to the RunningBuildIDs list
 	w.RunningBuildIDsMutex.Lock()
 
-	w.RunningBuildIDs = append(w.RunningBuildIDs, strconv.Itoa(item.Build.GetID()))
+	w.RunningBuildIDs = append(w.RunningBuildIDs, strconv.FormatInt(item.Build.GetID(), 10))
 
 	config.SetRunningBuildIDs(w.RunningBuildIDs)
 


### PR DESCRIPTION
it was populating the field with build numbers which are not as useful ;) 