### PR TITLE
fix: escape newline secrets before injection

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -590,6 +590,9 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			}
 		}
 
+		c.Logger.Debug("escaping newlines in secrets")
+		escapeNewlineSecrets(c.Secrets)
+
 		// inject secrets for container
 		err = injectSecrets(_step, c.Secrets)
 		if err != nil {

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -39,6 +39,9 @@ func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) err
 		return err
 	}
 
+	logger.Debug("escaping newlines in secrets")
+	escapeNewlineSecrets(c.Secrets)
+
 	logger.Debug("injecting secrets")
 	// inject secrets for container
 	err = injectSecrets(ctn, c.Secrets)


### PR DESCRIPTION
missing some newline escapes for services + lazy secrets

> thought: should we move this into `injectSecrets` ?