### PR TITLE
fix(secrets): run substitute after injection

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -587,16 +587,25 @@ func (c *client) ExecBuild(ctx context.Context) error {
 
 				// add secret to the map
 				c.Secrets[secret.Name] = s
+
+				c.Logger.Debug("escaping newlines in secrets")
+				escapeNewlineSecrets(c.Secrets)
+
+				// inject secrets for container
+				err = injectSecrets(_step, c.Secrets)
+				if err != nil {
+					return err
+				}
+
+				c.Logger.Debug("substituting container configuration")
+				// substitute container configuration
+				//
+				// https://pkg.go.dev/github.com/go-vela/types/pipeline#Container.Substitute
+				err = _step.Substitute()
+				if err != nil {
+					return fmt.Errorf("unable to substitute container configuration")
+				}
 			}
-		}
-
-		c.Logger.Debug("escaping newlines in secrets")
-		escapeNewlineSecrets(c.Secrets)
-
-		// inject secrets for container
-		err = injectSecrets(_step, c.Secrets)
-		if err != nil {
-			return err
 		}
 
 		c.Logger.Infof("planning %s step", _step.Name)


### PR DESCRIPTION
also, moved injection to only happen inside condition when we're dealing with `step_start` secrets, which leaves the regular path as it was in 0.21