### PR TITLE
fix(secrets): isolate lazy secret loading

### DIFF
--- a/executor/linux/build_test.go
+++ b/executor/linux/build_test.go
@@ -1139,6 +1139,20 @@ func TestLinux_PlanBuild(t *testing.T) {
 			runtime:  constants.DriverKubernetes,
 			pipeline: "testdata/build/stages/basic.yml",
 		},
+		{
+			name:     "docker-basic steps with lazy and regular secrets pipeline",
+			failure:  false,
+			logError: false,
+			runtime:  constants.DriverDocker,
+			pipeline: "testdata/build/steps/basic_secrets.yml",
+		},
+		{
+			name:     "kubernetes-basic steps with lazy and regular secrets pipeline",
+			failure:  false,
+			logError: false,
+			runtime:  constants.DriverKubernetes,
+			pipeline: "testdata/build/steps/basic_secrets.yml",
+		},
 	}
 
 	// run test
@@ -1620,6 +1634,20 @@ func TestLinux_ExecBuild(t *testing.T) {
 			logError: false,
 			runtime:  constants.DriverDocker,
 			pipeline: "testdata/build/steps/img_notfound.yml",
+		},
+		{
+			name:     "docker-basic steps with lazy and regular secrets pipeline",
+			failure:  false,
+			logError: false,
+			runtime:  constants.DriverDocker,
+			pipeline: "testdata/build/steps/basic_secrets.yml",
+		},
+		{
+			name:     "kubernetes-basic steps with lazy and regular secrets pipeline",
+			failure:  false,
+			logError: false,
+			runtime:  constants.DriverKubernetes,
+			pipeline: "testdata/build/steps/basic_secrets.yml",
 		},
 		//{
 		//	name:     "kubernetes-steps pipeline with image not found",

--- a/executor/linux/service.go
+++ b/executor/linux/service.go
@@ -39,9 +39,6 @@ func (c *client) CreateService(ctx context.Context, ctn *pipeline.Container) err
 		return err
 	}
 
-	logger.Debug("escaping newlines in secrets")
-	escapeNewlineSecrets(c.Secrets)
-
 	logger.Debug("injecting secrets")
 	// inject secrets for container
 	err = injectSecrets(ctn, c.Secrets)

--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -49,9 +49,6 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 		return err
 	}
 
-	logger.Debug("escaping newlines in secrets")
-	escapeNewlineSecrets(c.Secrets)
-
 	logger.Debug("injecting secrets")
 	// inject secrets for container
 	err = injectSecrets(ctn, c.Secrets)

--- a/executor/linux/testdata/build/steps/basic_secrets.yml
+++ b/executor/linux/testdata/build/steps/basic_secrets.yml
@@ -1,0 +1,22 @@
+---
+version: "1"
+steps:
+  - name: test
+    commands:
+      - echo ${FOO}
+    environment:
+      FOO: bar
+    image: alpine:latest
+    pull: true
+    secrets: [ lazy, regular ]
+
+secrets:
+  - name: lazy
+    key: github/octocat/lazy
+    engine: native
+    type: repo
+    pull: step_start
+  - name: regular
+    key: github/octocat/regular
+    engine: native
+    type: repo


### PR DESCRIPTION
this isolates operations for lazy loaded secrets and makes sure the secrets go through the same process as regular secrets. the current implementation had the potential to inadvertently result in unexpected secret values (even for regular secrets), in particular for multiline secrets and/or secrets with escaped newlines.

this also moves the `escapeNewlineSecrets()` on `c.Secrets` to be called once, instead of for however many steps (and services) a pipeline had. it was calling it over and over for the same secrets. this is not necessary for this fix, it's just excessive. if there's concern, i'm happy to remove from this PR.