### PR TITLE
enhance(logging): add info log prior to each download/use of an image during init step

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -271,6 +271,9 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		s.Detach = true
 
 		c.Logger.Infof("creating %s service", s.Name)
+
+		_log.AppendData([]byte(fmt.Sprintf("> Preparing service image %s...\n", s.Image)))
+
 		// create the service
 		c.err = c.CreateService(ctx, s)
 		if c.err != nil {
@@ -325,6 +328,8 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		if s.Name == "init" {
 			continue
 		}
+
+		_log.AppendData([]byte(fmt.Sprintf("> Preparing step image %s...\n", s.Image)))
 
 		c.Logger.Infof("creating %s step", s.Name)
 		// create the step

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -37,6 +37,8 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 		// update the container environment with stage name
 		_step.Environment["VELA_STEP_STAGE"] = s.Name
 
+		_log.AppendData([]byte(fmt.Sprintf("> Preparing step image %s...\n", _step.Image)))
+
 		logger.Debugf("creating %s step", _step.Name)
 		// create the step
 		err := c.CreateStep(ctx, _step)

--- a/executor/local/build.go
+++ b/executor/local/build.go
@@ -167,6 +167,8 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		// TODO: remove this; but we need it for tests
 		_service.Detach = true
 
+		fmt.Fprintln(c.stdout, _pattern, fmt.Sprintf("> Preparing service image %s...", _service.Image))
+
 		// create the service
 		c.err = c.CreateService(ctx, _service)
 		if c.err != nil {
@@ -212,6 +214,8 @@ func (c *client) AssembleBuild(ctx context.Context) error {
 		if _step.Name == "init" {
 			continue
 		}
+
+		fmt.Fprintln(c.stdout, _pattern, fmt.Sprintf("> Preparing step image %s...", _step.Image))
 
 		// create the step
 		c.err = c.CreateStep(ctx, _step)

--- a/executor/local/stage.go
+++ b/executor/local/stage.go
@@ -29,6 +29,8 @@ func (c *client) CreateStage(ctx context.Context, s *pipeline.Stage) error {
 		// update the container environment with stage name
 		_step.Environment["VELA_STEP_STAGE"] = s.Name
 
+		fmt.Fprintln(c.stdout, _pattern, fmt.Sprintf("> Preparing step image %s...", _step.Image))
+
 		// create the step
 		err := c.CreateStep(ctx, _step)
 		if err != nil {


### PR DESCRIPTION
## Description
Add an informational log prior to each download/use of an image during the initialization step of a build for visibility. 

### Desired View: Vela UI
<img width="1094" alt="Screenshot 2024-05-13 at 12 10 37 PM" src="https://github.com/go-vela/worker/assets/26553607/11696120-9085-461a-9fcb-808e90e9786d">

### Desired View: Local Execution
<img width="739" alt="Screenshot 2024-05-13 at 12 14 40 PM" src="https://github.com/go-vela/worker/assets/26553607/a361cd3d-9039-455d-be6d-bf84ebccc687">

## Related
https://github.com/go-vela/community/issues/915