### PR TITLE
fix: only add routes to registry worker if desired

### DIFF
--- a/cmd/vela-worker/operate.go
+++ b/cmd/vela-worker/operate.go
@@ -30,9 +30,13 @@ func (w *Worker) operate(ctx context.Context) error {
 	registryWorker := new(api.Worker)
 	registryWorker.SetHostname(w.Config.API.Address.Hostname())
 	registryWorker.SetAddress(w.Config.API.Address.String())
-	registryWorker.SetRoutes(w.Config.Queue.Routes)
 	registryWorker.SetActive(true)
 	registryWorker.SetBuildLimit(int64(w.Config.Build.Limit))
+
+	// set routes from config if set or defaulted to `vela`
+	if (len(w.Config.Queue.Routes) > 0) && (w.Config.Queue.Routes[0] != "NONE" && w.Config.Queue.Routes[0] != "") {
+		registryWorker.SetRoutes(w.Config.Queue.Routes)
+	}
 
 	// pull registration token from configuration if provided; wait if not
 	logrus.Trace("waiting for register token")


### PR DESCRIPTION
Due to this code block on start up:
```go
w.QueueCheckedIn, err = w.queueCheckIn(gctx, registryWorker)
```
And this code block after each build:
```go
// set worker status
updateStatus := w.getWorkerStatusFromConfig(config)
config.SetStatus(updateStatus)
config.SetLastStatusUpdateAt(time.Now().Unix())
config.SetLastBuildStartedAt(time.Now().Unix())

// update worker in the database
_, _, err = w.VelaClient.Worker.Update(config.GetHostname(), config)
if err != nil {
   logger.Errorf("unable to update worker: %v", err)
}
```

The routes get updated during normal operations based on what the worker has in its config. Since the default value is `vela`, and breaking that sounds like a bad idea, I think explicitly supplying an empty string or `"NONE"` should suffice to prevent these updates happening if the admins want the worker routes in the DB to persist.