### PR TITLE
fix(stream): add netrc password to mask targets

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -504,6 +504,12 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			continue
 		}
 
+		// add netrc to secrets for masking in logs
+		sec := &pipeline.StepSecret{
+			Target: "VELA_NETRC_PASSWORD",
+		}
+		_step.Secrets = append(_step.Secrets, sec)
+
 		// load any lazy secrets into the container environment
 		c.err = loadLazySecrets(c, _step)
 		if c.err != nil {

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -151,6 +151,12 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) 
 			continue
 		}
 
+		// add netrc to secrets for masking in logs
+		sec := &pipeline.StepSecret{
+			Target: "VELA_NETRC_PASSWORD",
+		}
+		_step.Secrets = append(_step.Secrets, sec)
+
 		// load any lazy secrets and inject them into container environment
 		err = loadLazySecrets(c, _step)
 		if err != nil {


### PR DESCRIPTION
This will help prevent accidental leakage of the netrc password used in builds