### PR TITLE
refactor: required changes from api build types migration

### DIFF
--- a/executor/linux/step.go
+++ b/executor/linux/step.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-vela/sdk-go/vela"
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
@@ -41,7 +42,7 @@ func (c *client) CreateStep(ctx context.Context, ctn *pipeline.Container) error 
 
 	// create a library step object to facilitate injecting environment as early as possible
 	// (PlanStep is too late to inject environment vars for the kubernetes runtime).
-	_step := library.StepFromBuildContainer(c.build.ToLibrary(), ctn)
+	_step := api.StepFromBuildContainer(c.build, ctn)
 
 	// update the step container environment
 	//
@@ -90,7 +91,7 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	logger := c.Logger.WithField("step", ctn.Name)
 
 	// create the library step object
-	_step := library.StepFromBuildContainer(c.build.ToLibrary(), ctn)
+	_step := api.StepFromBuildContainer(c.build, ctn)
 	_step.SetStatus(constants.StatusRunning)
 	_step.SetStarted(time.Now().UTC().Unix())
 

--- a/executor/local/step.go
+++ b/executor/local/step.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/pipeline"
@@ -50,7 +51,7 @@ func (c *client) PlanStep(ctx context.Context, ctn *pipeline.Container) error {
 	}
 
 	// create the library step object
-	_step := library.StepFromBuildContainer(c.build.ToLibrary(), ctn)
+	_step := api.StepFromBuildContainer(c.build, ctn)
 	_step.SetStatus(constants.StatusRunning)
 	_step.SetStarted(time.Now().UTC().Unix())
 

--- a/go.mod
+++ b/go.mod
@@ -149,5 +149,3 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
-
-replace github.com/go-vela/server => ../server

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/gin-gonic/gin v1.10.0
-	github.com/go-vela/sdk-go v0.25.1
-	github.com/go-vela/server v0.25.1
+	github.com/go-vela/sdk-go v0.25.0
+	github.com/go-vela/server v0.25.1-0.20241004140454-248b3a3ecf4b
 	github.com/go-vela/types v0.25.1
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
@@ -149,3 +149,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace github.com/go-vela/server => ../server

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-vela/sdk-go v0.25.0
-	github.com/go-vela/server v0.25.1-0.20241004140454-248b3a3ecf4b
+	github.com/go-vela/server v0.25.1-0.20241004194208-7e8a6762c8ef
 	github.com/go-vela/types v0.25.1
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-vela/sdk-go v0.25.0 h1:a5vGXEmwb8e+p+aK9W4b111FhiTDDSfR4HmEZckhgBk=
 github.com/go-vela/sdk-go v0.25.0/go.mod h1:UNXiPyDO8FGMinGgjw/LSS43Y8H+kyvxfAXIOSmEfB0=
+github.com/go-vela/server v0.25.1-0.20241004140454-248b3a3ecf4b h1:gCm1xvjr34McjS7kIgKVFcr96vGHnHnujndiM9W3Ktg=
+github.com/go-vela/server v0.25.1-0.20241004140454-248b3a3ecf4b/go.mod h1:/DmGHNzsjsBOStLzlGDIDGCmNztUgCdvHiuWmyafFs8=
 github.com/go-vela/types v0.25.1 h1:DCPHv1+ouqldjfsjfcVTcm/Yyd0OwazIfxYyR+GwpMo=
 github.com/go-vela/types v0.25.1/go.mod h1:5+MHUI9ZSY2Uz1cTJa64FWUv8jKzzUUq96UQTokGJzs=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=

--- a/go.sum
+++ b/go.sum
@@ -109,10 +109,8 @@ github.com/go-playground/validator/v10 v10.22.1 h1:40JcKH+bBNGFczGuoBYgX4I6m/i27
 github.com/go-playground/validator/v10 v10.22.1/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-vela/sdk-go v0.25.1 h1:aEWH88BjLmV5s3mWPbi7OeGY5u8IQ9xQNF8CWH3e5HU=
-github.com/go-vela/sdk-go v0.25.1/go.mod h1:98yxwcqGQidNke/QsbG8WeYJG56AImc9o9dcKiXBQ5k=
-github.com/go-vela/server v0.25.1 h1:KM3g5ZD3N6SnttnkfOyJjS2utbL6baKx0mGSJLCEf0c=
-github.com/go-vela/server v0.25.1/go.mod h1:QZ9troVMUpDCAdUxxAquHqahkeSwp9Lmx6a47ao0gGs=
+github.com/go-vela/sdk-go v0.25.0 h1:a5vGXEmwb8e+p+aK9W4b111FhiTDDSfR4HmEZckhgBk=
+github.com/go-vela/sdk-go v0.25.0/go.mod h1:UNXiPyDO8FGMinGgjw/LSS43Y8H+kyvxfAXIOSmEfB0=
 github.com/go-vela/types v0.25.1 h1:DCPHv1+ouqldjfsjfcVTcm/Yyd0OwazIfxYyR+GwpMo=
 github.com/go-vela/types v0.25.1/go.mod h1:5+MHUI9ZSY2Uz1cTJa64FWUv8jKzzUUq96UQTokGJzs=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-vela/sdk-go v0.25.0 h1:a5vGXEmwb8e+p+aK9W4b111FhiTDDSfR4HmEZckhgBk=
 github.com/go-vela/sdk-go v0.25.0/go.mod h1:UNXiPyDO8FGMinGgjw/LSS43Y8H+kyvxfAXIOSmEfB0=
-github.com/go-vela/server v0.25.1-0.20241004140454-248b3a3ecf4b h1:gCm1xvjr34McjS7kIgKVFcr96vGHnHnujndiM9W3Ktg=
-github.com/go-vela/server v0.25.1-0.20241004140454-248b3a3ecf4b/go.mod h1:/DmGHNzsjsBOStLzlGDIDGCmNztUgCdvHiuWmyafFs8=
+github.com/go-vela/server v0.25.1-0.20241004194208-7e8a6762c8ef h1:XQsek564/h2AdwYRt4vF2x7U+hNxZzmGGsTc7wMUd74=
+github.com/go-vela/server v0.25.1-0.20241004194208-7e8a6762c8ef/go.mod h1:/DmGHNzsjsBOStLzlGDIDGCmNztUgCdvHiuWmyafFs8=
 github.com/go-vela/types v0.25.1 h1:DCPHv1+ouqldjfsjfcVTcm/Yyd0OwazIfxYyR+GwpMo=
 github.com/go-vela/types v0.25.1/go.mod h1:5+MHUI9ZSY2Uz1cTJa64FWUv8jKzzUUq96UQTokGJzs=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=


### PR DESCRIPTION
depends on: https://github.com/go-vela/server/pull/1204 

this is subject to change when `pipeline` and `step` are migrated, but until then we need it to build the worker

```bash
make build

executor/local/step.go:53:50: c.build.ToLibrary undefined (type *"github.com/go-vela/server/api/types".Build has no field or method ToLibrary)
```