### PR TITLE
fix(exec): dereference outputs container config for executor setup

### DIFF
--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -144,8 +144,11 @@ func (w *Worker) exec(index int, config *api.Worker) error {
 		break
 	}
 
-	// set the outputs container ID
-	w.Config.Executor.OutputCtn.ID = fmt.Sprintf("outputs_%s", p.ID)
+	// dereference configured outputs ctn config and set the outputs container ID for the executor
+	//
+	// need to dereference to avoid executors sharing the last set outputs container config
+	execOutputCtn := *w.Config.Executor.OutputCtn
+	execOutputCtn.ID = fmt.Sprintf("outputs_%s", p.ID)
 
 	// create logger with extra metadata
 	//
@@ -238,7 +241,7 @@ func (w *Worker) exec(index int, config *api.Worker) error {
 		Build:               item.Build,
 		Pipeline:            p.Sanitize(w.Config.Runtime.Driver),
 		Version:             v.Semantic(),
-		OutputCtn:           w.Config.Executor.OutputCtn,
+		OutputCtn:           &execOutputCtn,
 	})
 
 	// add the executor to the worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       QUEUE_DRIVER: redis
       # comment the line below to source Redis address from server
       QUEUE_ADDR: 'redis://redis:6379'
-      VELA_BUILD_LIMIT: 1
+      VELA_BUILD_LIMIT: 3
       VELA_BUILD_TIMEOUT: 30m
       VELA_LOG_LEVEL: trace
       VELA_RUNTIME_DRIVER: docker


### PR DESCRIPTION
This fixes an error where all executors try to share the outputs container config of whichever exec process last set it.

I'm also increasing the local stack build limit to 3 because this will help prevent future issues like this without sacrificing any sort of convenience for developers.