### PR TITLE
fix(patch/v25.2): apply worker status fix

### DIFF
--- a/cmd/vela-worker/register.go
+++ b/cmd/vela-worker/register.go
@@ -73,8 +73,11 @@ func (w *Worker) checkIn(config *api.Worker) (bool, string, error) {
 
 			return false, "", fmt.Errorf("unable to refresh auth for worker %s on the server: %w", config.GetHostname(), err)
 		}
+
+		status := w.getWorkerStatusFromConfig(config)
+
 		// update worker status to Idle when checkIn is successful.
-		w.updateWorkerStatus(config, constants.WorkerStatusIdle)
+		w.updateWorkerStatus(config, status)
 
 		break
 	}
@@ -113,8 +116,10 @@ func (w *Worker) queueCheckIn(ctx context.Context, registryWorker *api.Worker) (
 		return false, pErr
 	}
 
+	status := w.getWorkerStatusFromConfig(registryWorker)
+
 	// update worker status to Idle when setup and ping are good.
-	w.updateWorkerStatus(registryWorker, constants.WorkerStatusIdle)
+	w.updateWorkerStatus(registryWorker, status)
 
 	return true, nil
 }


### PR DESCRIPTION
Applying https://github.com/go-vela/worker/pull/611 to `v0.25.2` patch release