### PR TITLE
fix(patch/v25.2): dereference outputs ctn config

### DIFF
--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -146,8 +146,11 @@ func (w *Worker) exec(index int, config *api.Worker) error {
 		break
 	}
 
-	// set the outputs container ID
-	w.Config.Executor.OutputCtn.ID = fmt.Sprintf("outputs_%s", p.ID)
+	// dereference configured outputs ctn config and set the outputs container ID for the executor
+	//
+	// need to dereference to avoid executors sharing the last set outputs container config
+	execOutputCtn := *w.Config.Executor.OutputCtn
+	execOutputCtn.ID = fmt.Sprintf("outputs_%s", p.ID)
 
 	// create logger with extra metadata
 	//
@@ -240,7 +243,7 @@ func (w *Worker) exec(index int, config *api.Worker) error {
 		Build:               item.Build,
 		Pipeline:            p.Sanitize(w.Config.Runtime.Driver),
 		Version:             v.Semantic(),
-		OutputCtn:           w.Config.Executor.OutputCtn,
+		OutputCtn:           &execOutputCtn,
 	})
 
 	// add the executor to the worker


### PR DESCRIPTION
Applying https://github.com/go-vela/worker/pull/612 to patch `v0.25.2`