### PR TITLE
fix(secret): prevent spillover of init logs into downstream steps

### DIFF
--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -287,7 +287,7 @@ func (s *secretSvc) stream(ctx context.Context, ctn *pipeline.Container) error {
 		// send API call to update the logs for the service
 		//
 		// https://pkg.go.dev/github.com/go-vela/sdk-go/vela#LogService.UpdateService
-		_, err = s.client.Vela.Log.UpdateStep(s.client.build.GetRepo().GetOrg(), s.client.build.GetRepo().GetName(), s.client.build.GetNumber(), ctn.Number, _log)
+		_, err = s.client.Vela.Log.UpdateStep(s.client.build.GetRepo().GetOrg(), s.client.build.GetRepo().GetName(), s.client.build.GetNumber(), s.client.init.Number, _log)
 		if err != nil {
 			logger.Errorf("unable to upload container logs: %v", err)
 		}


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/1013
Closes https://github.com/go-vela/community/issues/985

`ctn.Number` does not reflect step number in this case. We always want to target the init step on this deferred log upload.

The number of steps that had spillage was directly correlated to how many secret plugin containers were being executed.

Tough find!