### PR TITLE
fix(ci): disable CGO for static CI builds in workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,7 +38,7 @@ jobs:
       - name: build
         env:
           GOOS: linux
-          CGO_ENABLED: "1"
+          CGO_ENABLED: "0"
         run: |
           make build-static-ci
 
@@ -93,7 +93,7 @@ jobs:
       - name: build
         env:
           GOOS: linux
-          CGO_ENABLED: "1"
+          CGO_ENABLED: "0"
         run: |
           make build-static-ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: build
         env:
           GOOS: linux
-          CGO_ENABLED: "1"
+          CGO_ENABLED: "0"
         run: |
           make build-static-ci
 
@@ -82,7 +82,7 @@ jobs:
       - name: build
         env:
           GOOS: linux
-          CGO_ENABLED: "1"
+          CGO_ENABLED: "0"
         run: |
           make build-static-ci
 


### PR DESCRIPTION
I think this is causing issues with our binary in our current `v0.27.0-rc1` image