### PR TITLE
enhance(outputs): add base64 option that is automatically decoded

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   # https://go-vela.github.io/docs/administration/server/
   server:
     container_name: server
-    image: target/vela-server:latest
+    image: server:local
     networks:
       - vela
     environment:

--- a/executor/linux/outputs.go
+++ b/executor/linux/outputs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"maps"
 
 	envparse "github.com/hashicorp/go-envparse"
 	"github.com/sirupsen/logrus"
@@ -120,30 +121,85 @@ func (o *outputSvc) poll(ctx context.Context, ctn *pipeline.Container) (map[stri
 
 	logger.Debug("tailing container")
 
-	// grab outputs
-	outputBytes, err := o.client.Runtime.PollOutputsContainer(ctx, ctn, "/vela/outputs/.env")
-	if err != nil {
-		return nil, nil, err
-	}
+	var (
+		filePaths = []string{
+			"/vela/outputs/.env",
+			"/vela/outputs/masked.env",
+			"/vela/outputs/base64.env",
+			"/vela/outputs/masked.base64.env",
+		}
 
-	reader := bytes.NewReader(outputBytes)
+		outputMap = make(map[string]string)
+		maskMap   = make(map[string]string)
+	)
 
-	outputMap, err := envparse.Parse(reader)
-	if err != nil {
-		logger.Debugf("unable to parse output map: %v", err)
-	}
+	for _, p := range filePaths {
+		outputBytes, err := o.client.Runtime.PollOutputsContainer(ctx, ctn, p)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to poll outputs container %s: %w", ctn.Name, err)
+		}
 
-	// grab masked outputs
-	maskedBytes, err := o.client.Runtime.PollOutputsContainer(ctx, ctn, "/vela/outputs/masked.env")
-	if err != nil {
-		return nil, nil, err
-	}
+		reader := bytes.NewReader(outputBytes)
 
-	reader = bytes.NewReader(maskedBytes)
+		switch p {
+		case "/vela/outputs/.env":
+			parsed, err := envparse.Parse(reader)
+			if err != nil {
+				logger.Debugf("unable to parse output map: %v", err)
+			}
 
-	maskMap, err := envparse.Parse(reader)
-	if err != nil {
-		logger.Debugf("unable to parse masked output map: %v", err)
+			// add to output map
+			maps.Copy(outputMap, parsed)
+
+		case "/vela/outputs/masked.env":
+			parsed, err := envparse.Parse(reader)
+			if err != nil {
+				logger.Debugf("unable to parse masked output map: %v", err)
+			}
+
+			// add to mask map
+			maps.Copy(maskMap, parsed)
+
+		case "/vela/outputs/base64.env":
+			parsed, err := envparse.Parse(reader)
+			if err != nil {
+				logger.Debugf("unable to parse base64 output map: %v", err)
+			}
+
+			for k, v := range parsed {
+				// decode the base64 value
+				decodedValue, err := base64.StdEncoding.DecodeString(v)
+				if err != nil {
+					logger.Debugf("unable to decode base64 value for key %s: %v", k, err)
+					continue
+				}
+
+				parsed[k] = string(decodedValue)
+			}
+
+			// add to output map
+			maps.Copy(outputMap, parsed)
+
+		case "/vela/outputs/masked.base64.env":
+			parsed, err := envparse.Parse(reader)
+			if err != nil {
+				logger.Debugf("unable to parse masked base64 output map: %v", err)
+			}
+
+			for k, v := range parsed {
+				// decode the base64 value
+				decodedValue, err := base64.StdEncoding.DecodeString(v)
+				if err != nil {
+					logger.Debugf("unable to decode base64 value for key %s: %v", k, err)
+					continue
+				}
+
+				parsed[k] = string(decodedValue)
+			}
+
+			// add to mask map
+			maps.Copy(maskMap, parsed)
+		}
 	}
 
 	return outputMap, maskMap, nil

--- a/executor/linux/secret.go
+++ b/executor/linux/secret.go
@@ -47,6 +47,8 @@ func (s *secretSvc) create(ctx context.Context, ctn *pipeline.Container, reqToke
 	ctn.Environment["VELA_VERSION"] = s.client.Version
 	ctn.Environment["VELA_OUTPUTS"] = "/vela/outputs/.env"
 	ctn.Environment["VELA_MASKED_OUTPUTS"] = "/vela/outputs/masked.env"
+	ctn.Environment["VELA_BASE64_OUTPUTS"] = "/vela/outputs/base64.env"
+	ctn.Environment["VELA_MASKED_BASE64_OUTPUTS"] = "/vela/outputs/masked.base64.env"
 
 	if len(reqToken) > 0 {
 		ctn.Environment["VELA_ID_TOKEN_REQUEST_TOKEN"] = reqToken

--- a/internal/step/environment.go
+++ b/internal/step/environment.go
@@ -35,6 +35,8 @@ func Environment(c *pipeline.Container, b *api.Build, s *api.Step, version, reqT
 		c.Environment["VELA_ID_TOKEN_REQUEST_TOKEN"] = reqToken
 		c.Environment["VELA_OUTPUTS"] = "/vela/outputs/.env"
 		c.Environment["VELA_MASKED_OUTPUTS"] = "/vela/outputs/masked.env"
+		c.Environment["VELA_BASE64_OUTPUTS"] = "/vela/outputs/base64.env"
+		c.Environment["VELA_MASKED_BASE64_OUTPUTS"] = "/vela/outputs/masked.base64.env"
 
 		// populate environment variables from build library
 		err := c.MergeEnv(b.Environment(workspace))


### PR DESCRIPTION
To avoid issues with special characters, I think having a base64 outputs option would be convenient.