### PR TITLE
enhance(client): use scm token as secondary auth header for exec client

### DIFF
--- a/cmd/vela-worker/client.go
+++ b/cmd/vela-worker/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-vela/sdk-go/vela"
 )
 
-// helper function to setup the vela API client for worker check-in.
+// helper function to setup the vela API client for worker check-in and build executable retrieval.
 func setupClient(s *Server, token string) (*vela.Client, error) {
 	logrus.Debug("creating vela client from worker configuration")
 

--- a/cmd/vela-worker/client.go
+++ b/cmd/vela-worker/client.go
@@ -8,21 +8,30 @@ import (
 	"github.com/go-vela/sdk-go/vela"
 )
 
-// helper function to setup the queue from the CLI arguments.
+// helper function to setup the vela API client for worker check-in.
 func setupClient(s *Server, token string) (*vela.Client, error) {
 	logrus.Debug("creating vela client from worker configuration")
 
-	// create a new Vela client from the server configuration
-	//
-	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela#NewClient
 	vela, err := vela.NewClient(s.Address, "", nil)
 	if err != nil {
 		return nil, err
 	}
-	// set token for authentication with the server
-	//
-	// https://pkg.go.dev/github.com/go-vela/sdk-go/vela#AuthenticationService.SetTokenAuth
+
 	vela.Authentication.SetTokenAuth(token)
+
+	return vela, nil
+}
+
+// helper function to setup the vela API client for executor calls to update build resources.
+func setupExecClient(s *Server, buildToken, scmToken string) (*vela.Client, error) {
+	logrus.Debug("creating vela client from worker configuration")
+
+	vela, err := vela.NewClient(s.Address, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	vela.Authentication.SetBuildTokenAuth(buildToken, scmToken)
 
 	return vela, nil
 }

--- a/cmd/vela-worker/exec.go
+++ b/cmd/vela-worker/exec.go
@@ -105,7 +105,7 @@ func (w *Worker) exec(index int, config *api.Worker) error {
 			return err
 		}
 
-		// set up build client with build token as auth
+		// set up temporary client with build token as auth since we do not have scm token yet
 		execBuildClient, err = setupClient(w.Config.Server, bt.GetToken())
 		if err != nil {
 			// check if the retry limit has been exceeded
@@ -137,6 +137,12 @@ func (w *Worker) exec(index int, config *api.Worker) error {
 		p = new(pipeline.Build)
 
 		err = json.Unmarshal(execBuildExecutable.GetData(), p)
+		if err != nil {
+			return err
+		}
+
+		// setup exec client with scm token and build token
+		execBuildClient, err = setupExecClient(w.Config.Server, bt.GetToken(), p.Token)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/gin-gonic/gin v1.10.1
-	github.com/go-vela/sdk-go v0.27.0
-	github.com/go-vela/server v0.27.0
+	github.com/go-vela/sdk-go v0.27.1-0.20250822171227-07d7ba2a3c5c
+	github.com/go-vela/server v0.27.1-0.20250818162730-1fd92adf65b3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -121,10 +121,10 @@ github.com/go-playground/validator/v10 v10.26.0 h1:SP05Nqhjcvz81uJaRfEV0YBSSSGMc
 github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-vela/sdk-go v0.27.0 h1:nVK58o1n0brl7g8W9Hva+WnlsjCX11b2FGCCuSPkVQg=
-github.com/go-vela/sdk-go v0.27.0/go.mod h1:3YyFgyxcvVzqVyrB/ThsPRkNsgf+oobgWFGkPwjLDjI=
-github.com/go-vela/server v0.27.0 h1:QUcThEP67UnLvf4YPp7dOPQgRL9MgYI2xYjGops4B5g=
-github.com/go-vela/server v0.27.0/go.mod h1:Zlqc4UMaURd1NWTaMy1uw98lKwj2HrCp6BswnL8fpKI=
+github.com/go-vela/sdk-go v0.27.1-0.20250822171227-07d7ba2a3c5c h1:lGOSzSIYznKdVGJ7ixqQN95rI6IQVb9yOrmFd7jsjN0=
+github.com/go-vela/sdk-go v0.27.1-0.20250822171227-07d7ba2a3c5c/go.mod h1:F440hQvXd0fSTMCJ93XcTQEBcLxKm6cYaDbOpepdq8A=
+github.com/go-vela/server v0.27.1-0.20250818162730-1fd92adf65b3 h1:KXZ8VNdSevGdE/fu543JZSsdb7gCrCWHv27PI0n2uBo=
+github.com/go-vela/server v0.27.1-0.20250818162730-1fd92adf65b3/go.mod h1:Zlqc4UMaURd1NWTaMy1uw98lKwj2HrCp6BswnL8fpKI=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=


### PR DESCRIPTION
Follow up from https://github.com/go-vela/server/pull/1337 and https://github.com/go-vela/sdk-go/pull/369