### PR TITLE
fix(exec): use client err for substitution failures and delay PlanStep

### DIFF
--- a/executor/linux/build.go
+++ b/executor/linux/build.go
@@ -532,28 +532,28 @@ func (c *client) ExecBuild(ctx context.Context) error {
 			return fmt.Errorf("unable to plan step: %w", c.err)
 		}
 
-		c.Logger.Infof("planning %s step", _step.Name)
-		// plan the step
-		c.err = c.PlanStep(ctx, _step)
-		if c.err != nil {
-			return fmt.Errorf("unable to plan step: %w", c.err)
-		}
-
 		// setup commands script
 		//
 		// this is done before substitution to ensure that YAML scalars in commands blocks do not throw off substitution for runtime vars
 		_step.Script()
 
 		// perform any substitution on dynamic variables
-		err = _step.Substitute()
-		if err != nil {
-			return err
+		c.err = _step.Substitute()
+		if c.err != nil {
+			return fmt.Errorf("unable to substitute step: %w", c.err)
 		}
 
 		// inject no-substitution secrets for container
-		err = injectSecrets(_step, c.NoSubSecrets)
-		if err != nil {
-			return err
+		c.err = injectSecrets(_step, c.NoSubSecrets)
+		if c.err != nil {
+			return fmt.Errorf("unable to inject secrets: %w", c.err)
+		}
+
+		c.Logger.Infof("planning %s step", _step.Name)
+		// plan the step
+		c.err = c.PlanStep(ctx, _step)
+		if c.err != nil {
+			return fmt.Errorf("unable to plan step: %w", c.err)
 		}
 
 		c.Logger.Infof("executing %s step", _step.Name)

--- a/executor/linux/stage.go
+++ b/executor/linux/stage.go
@@ -158,13 +158,6 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) 
 			return fmt.Errorf("unable to plan step %s: %w", _step.Name, err)
 		}
 
-		logger.Debugf("planning %s step", _step.Name)
-		// plan the step
-		err = c.PlanStep(ctx, _step)
-		if err != nil {
-			return fmt.Errorf("unable to plan step %s: %w", _step.Name, err)
-		}
-
 		// poll outputs
 		opEnv, maskEnv, err := c.outputs.poll(ctx, c.OutputCtn)
 		if c.err != nil {
@@ -189,6 +182,13 @@ func (c *client) ExecStage(ctx context.Context, s *pipeline.Stage, m *sync.Map) 
 		err = injectSecrets(_step, c.NoSubSecrets)
 		if err != nil {
 			return err
+		}
+
+		logger.Debugf("planning %s step", _step.Name)
+		// plan the step
+		err = c.PlanStep(ctx, _step)
+		if err != nil {
+			return fmt.Errorf("unable to plan step %s: %w", _step.Name, err)
 		}
 
 		logger.Infof("executing %s step", _step.Name)


### PR DESCRIPTION
Any substitution errors were failing silently and not being relayed to the user in any fashion. Further, because PlanStep was executed before the substitution, the step is marked as `running` and is not properly cleaned up.

By using `c.err`, the build will bomb out expectedly if there's a container config breaking error and will also set the upcoming step as `skipped` instead of `success` when it's all said and done.

Example Pipeline:
```yaml
version: "1"

steps:
  - name: sleepy
    image: hub.docker.target.com/alpine:latest
    commands:
      - sleep 5

  - name: mess up
    image: hub.docker.target.com/alpine:latest
    parameters:
      tags:
        - ${VELA_BUILD_NUMBER:0:8} // FAILED SUBSTITUTION (number cannot be indexed :0:8)
    commands:
      - echo "This is a test"
```

BEFORE:
<img width="1702" height="552" alt="Screenshot 2026-04-30 at 1 02 03 PM" src="https://github.com/user-attachments/assets/0aa2bff4-5b6d-4a12-9bf2-5ddcbdaeb4a5" />


AFTER:
<img width="1655" height="822" alt="Screenshot 2026-04-30 at 1 02 43 PM" src="https://github.com/user-attachments/assets/b02ed0f2-696a-498f-a3a4-3b5405ef0d94" />

